### PR TITLE
security: add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 dist/
 *.tgz
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
Prevents accidental commit of MEMOCLAW_PRIVATE_KEY and other secrets.

### Audit findings
- No hardcoded secrets ✅
- No command injection (user input only used as HTTP request body) ✅
- Private key read from env var with fail-fast ✅
