### PR TITLE
feat: v1.7.0 — graph, purge, count + network error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.7.0
+
+### New Commands
+- `memoclaw graph <id>` — ASCII tree visualization of memory relations (color-coded by relation type)
+- `memoclaw purge` — Delete all memories with confirmation prompt (or `--force` to skip)
+- `memoclaw count` — Quick memory count, pipe-friendly (just prints the number)
+
+### Improvements
+- **Network error handling** — Friendly messages for DNS failures, connection refused, timeouts instead of raw stack traces
+- **`--force` flag** — Skip confirmation prompts (for `purge` and future destructive commands)
+- **`--timeout` flag** — Configurable request timeout (default: 30s)
+- **21 commands total** — Up from 18; shell completions updated
+
+### Testing
+- 53 tests (up from 46), covering new commands, graph helpers, boolean flags
+
 ## 1.6.0
 
 ### New Commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MemoClaw CLI - Memory-as-a-Service for AI agents. 1000 free calls, then x402 micropayments.",
   "type": "module",
   "bin": {

--- a/src/args.ts
+++ b/src/args.ts
@@ -10,6 +10,7 @@ export interface ParsedArgs {
 /** Boolean-only flags that never take a value */
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
+  'force', 'count', 'wide',
 ]);
 
 /** Short flag aliases */


### PR DESCRIPTION
## What's New

### New Commands (3)
- **`memoclaw graph <id>`** — ASCII tree visualization of memory relations, color-coded by type (contradicts=red, supports=green, etc.)
- **`memoclaw purge`** — Delete all memories with interactive confirmation, or `--force` to skip. Supports `--namespace` filtering.
- **`memoclaw count`** — Pipe-friendly memory count (just prints the number). Great for `memoclaw count | xargs echo` workflows.

### Improvements
- **Network error handling** — Friendly messages for DNS failures, connection refused, and timeouts instead of raw stack traces
- **`--force` flag** — Skip confirmation prompts for destructive operations
- **`--timeout <seconds>`** — Configurable request timeout (default: 30s)
- **21 total commands** with updated shell completions

### Testing
- **53 tests** (up from 46), all passing
- New coverage: graph helpers, new command routing, boolean flag extensions

### Version bump
1.6.0 → 1.7.0