### PR TITLE
feat: CLI v2 power features (v1.5–1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,46 +14,119 @@ npm install -g memoclaw
 export MEMOCLAW_PRIVATE_KEY=0x...  # Your wallet private key
 ```
 
-## Usage
+## Quick Start
 
 ```bash
 # Store a memory
 memoclaw store "learned that user prefers dark mode" --importance 0.8 --tags ui,preferences
 
-# Recall memories
+# Recall memories by similarity
 memoclaw recall "user preferences" --limit 5
 
-# List all memories
-memoclaw list --limit 20
+# List all memories (pretty table)
+memoclaw list
 
-# Update a memory
-memoclaw update <id> --importance 0.9 --pinned true
+# Interactive browser
+memoclaw browse
+```
 
-# Delete a memory
-memoclaw delete <id>
+## Commands
 
-# Ingest raw text (auto-extracts memories)
-memoclaw ingest --text "Meeting notes: decided to use Rust for the backend..."
-cat transcript.txt | memoclaw ingest
+### Core
 
-# Extract memories from text
-memoclaw extract "The project deadline is March 15th and we need 3 engineers"
+```bash
+memoclaw store "content"              # Store a memory (also accepts stdin)
+memoclaw recall "query"               # Search by semantic similarity
+memoclaw list                         # List memories in a table
+memoclaw get <id>                     # Get a single memory
+memoclaw update <id> --importance 0.9 # Update a memory
+memoclaw delete <id>                  # Delete a memory
+memoclaw count                        # Quick count (pipe-friendly)
+```
 
-# Consolidate duplicate memories
-memoclaw consolidate --dry-run
-memoclaw consolidate --min-similarity 0.85
+### AI Features
 
-# Manage relations between memories
+```bash
+memoclaw ingest --text "Meeting notes..."  # Auto-extract memories from text
+cat transcript.txt | memoclaw ingest       # Pipe text to ingest
+memoclaw extract "The deadline is March 15th"
+memoclaw consolidate --dry-run             # Merge similar memories
+memoclaw suggested --category stale        # Review suggested memories
+```
+
+### Relations
+
+```bash
 memoclaw relations list <memory-id>
 memoclaw relations create <memory-id> <target-id> related_to
 memoclaw relations delete <memory-id> <relation-id>
+memoclaw graph <id>                        # ASCII tree visualization
+```
 
-# Review suggested memories (stale, decaying, etc.)
-memoclaw suggested --category stale
-memoclaw suggested --raw
+Valid relation types: `related_to`, `derived_from`, `contradicts`, `supersedes`, `supports`
 
-# Check free tier status
-memoclaw status
+### Bulk Operations
+
+```bash
+memoclaw export > backup.json              # Export all memories
+memoclaw export --namespace project1 > p1.json
+memoclaw import --file backup.json         # Import from file
+cat backup.json | memoclaw import          # Import from stdin
+memoclaw purge --force                     # Delete ALL memories
+memoclaw purge --namespace old --force     # Delete namespace
+```
+
+### Account & Config
+
+```bash
+memoclaw status                            # Free tier remaining
+memoclaw stats                             # Memory statistics
+memoclaw config show                       # Show configuration
+memoclaw config check                      # Validate setup
+```
+
+### Interactive Browser
+
+```bash
+memoclaw browse                            # REPL for exploring memories
+memoclaw browse --namespace project1
+```
+
+Inside the browser: `list`, `get <id>`, `recall <query>`, `store <text>`, `delete <id>`, `stats`, `next`, `prev`, `quit`
+
+### Shell Completions
+
+```bash
+eval "$(memoclaw completions bash)"
+eval "$(memoclaw completions zsh)"
+memoclaw completions fish > ~/.config/fish/completions/memoclaw.fish
+```
+
+## Global Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--json` | `-j` | Machine-readable JSON output |
+| `--quiet` | `-q` | Suppress non-essential output |
+| `--namespace <name>` | `-n` | Filter/set namespace |
+| `--limit <n>` | `-l` | Limit results |
+| `--tags <a,b>` | `-t` | Comma-separated tags |
+| `--raw` | | Content only (for piping) |
+| `--force` | | Skip confirmation prompts |
+| `--timeout <sec>` | | Request timeout (default: 30) |
+| `--help` | `-h` | Show help |
+| `--version` | `-v` | Show version |
+
+Flags can be combined: `memoclaw list -jq -n myns -l 5`
+
+## Piping
+
+```bash
+echo "meeting notes" | memoclaw store
+echo "long text" | memoclaw ingest
+memoclaw recall "query" --raw | head -1
+memoclaw export | jq '.memories | length'
+memoclaw count  # outputs just the number
 ```
 
 ## Environment Variables
@@ -62,17 +135,18 @@ memoclaw status
 |----------|----------|-------------|
 | `MEMOCLAW_PRIVATE_KEY` | Yes | Wallet private key for auth + payments |
 | `MEMOCLAW_URL` | No | API endpoint (default: `https://api.memoclaw.com`) |
+| `NO_COLOR` | No | Disable colored output |
 | `DEBUG` | No | Enable debug logging |
 
 ## Free Tier
 
 Every wallet gets **1000 free API calls**. After that, x402 micropayments kick in automatically — $0.001/call in USDC on Base. No signup, no API keys, just your wallet.
 
-## API
+## Links
 
-- Dashboard: [https://memoclaw.com](https://memoclaw.com)
-- API: [https://api.memoclaw.com](https://api.memoclaw.com)
-- Docs: [https://docs.memoclaw.com](https://docs.memoclaw.com)
+- Dashboard: [memoclaw.com](https://memoclaw.com)
+- API: [api.memoclaw.com](https://api.memoclaw.com)
+- Docs: [docs.memoclaw.com](https://docs.memoclaw.com)
 
 ## License
 


### PR DESCRIPTION
## Summary

Major CLI overhaul bundling v1.5, v1.6, and v1.7 features into a single PR.

### New Commands (8 total)
- `export` / `import` — Bulk backup & restore with progress bars
- `stats` — Memory statistics + account overview
- `completions` — Shell completions for bash/zsh/fish
- `browse` — Interactive REPL memory browser
- `config` — Show/validate configuration
- `graph` — ASCII tree of memory relations
- `purge` — Delete all memories (with confirmation)
- `count` — Pipe-friendly memory count

### Fixes
- Falsy value bugs (importance=0, limit=0 no longer ignored)
- Boolean flags no longer consume the next argument
- Network errors show friendly messages instead of stack traces
- Update with no fields gives clear error

### Output & UX
- `--json` / `-j` flag for machine-readable output on all commands
- `--quiet` / `-q` flag to suppress decorative output
- `--raw` flag for pipe-friendly content-only output
- Pretty tables for `list` and `relations list`
- Color-coded similarity scores, categories, relation types
- Progress bars for import/export
- Short flags: `-n`, `-l`, `-t`, `-o` + combined flags (`-jq`)
- `--key=value` syntax support
- Per-command help: `memoclaw help <command>`

### Piping Support
- `echo ... | memoclaw store`
- `echo ... | memoclaw ingest`
- `echo ... | memoclaw extract`
- `cat backup.json | memoclaw import`
- `memoclaw export | jq ...`
- `memoclaw count` outputs just the number

### Architecture
- Shared arg parser extracted to `src/args.ts`
- Lazy auth (help/version work without private key)
- Respects `NO_COLOR` and non-TTY environments

### Testing
- **53 tests**, 130 expect() calls, all passing
- Covers: arg parsing, short/combined flags, kebab-case, output formatting, relation validation, import/export format, graph helpers

### Stats
- +790 lines added across 5 files
- 21 commands total