### PR TITLE
fix: shell completions, import concurrency, test coverage

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -280,12 +280,12 @@ describe('export format', () => {
 // ─── Completions ─────────────────────────────────────────────────────────────
 
 describe('completions', () => {
-  const commands = ['store', 'recall', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
+  const commands = ['init', 'migrate', 'store', 'recall', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
     'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
-    'completions', 'config', 'graph', 'purge', 'count'];
+    'completions', 'config', 'graph', 'purge', 'count', 'namespace', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(21);
+    expect(commands.length).toBe(25);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
     expect(commands).toContain('export');
@@ -297,6 +297,10 @@ describe('completions', () => {
     expect(commands).toContain('graph');
     expect(commands).toContain('purge');
     expect(commands).toContain('count');
+    expect(commands).toContain('init');
+    expect(commands).toContain('migrate');
+    expect(commands).toContain('namespace');
+    expect(commands).toContain('help');
   });
 });
 
@@ -396,6 +400,28 @@ describe('new command routing', () => {
   test('timeout flag parsed as value', () => {
     const args = parseArgs(['list', '--timeout', '60']);
     expect(args.timeout).toBe('60');
+  });
+
+  test('init command with --force', () => {
+    const args = parseArgs(['init', '--force']);
+    const [cmd] = args._;
+    expect(cmd).toBe('init');
+    expect(args.force).toBe(true);
+  });
+
+  test('migrate command with path', () => {
+    const args = parseArgs(['migrate', '/path/to/dir', '--namespace', 'imported']);
+    const [cmd, ...rest] = args._;
+    expect(cmd).toBe('migrate');
+    expect(rest[0]).toBe('/path/to/dir');
+    expect(args.namespace).toBe('imported');
+  });
+
+  test('help command with subcommand', () => {
+    const args = parseArgs(['help', 'store']);
+    const [cmd, ...rest] = args._;
+    expect(cmd).toBe('help');
+    expect(rest[0]).toBe('store');
   });
 });
 


### PR DESCRIPTION
## Changes

### Bug fixes
- **Shell completions missing commands**: `init`, `migrate`, `namespace`, `help` were not in the completions command list (25 commands total now)
- **Import default concurrency too low**: Increased from 1 to 5 to reduce import time while staying within rate limits

### Improvements  
- **Rich shell completions**: Bash/zsh/fish now complete:
  - Global flags (`--json`, `--format`, `--namespace`, etc.)
  - Subcommands (`relations list/create/delete`, `config show/check/init/path`, `namespace list/stats`, `completions bash/zsh/fish`)
  - Format values after `--format` (json, table, csv, yaml)
- **Help listing**: Added `help` command to the help text output

### Tests
- Fixed completions test (hardcoded 21 commands → 25)
- Added routing tests for `init`, `migrate`, `help` commands
- **133 tests passing**

### Notes
- Did not touch `dist/` — build verified locally
- No changes to `main` branch