### PR TITLE
feat: add search command for free text search

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -11,7 +11,7 @@ export interface ParsedArgs {
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
   'force', 'count', 'wide', 'pretty', 'watch', 'interactive', 'yes', 'reverse',
-  'noTruncate', 'invert', 'ascending',
+  'noTruncate',
 ]);
 
 /** Short flag aliases */
@@ -43,8 +43,6 @@ const SHORT_FLAGS: Record<string, string> = {
   '-k': 'columns',
   '-O': 'output',
   '-F': 'field',
-  '-a': 'ascending',
-  '-I': 'invert',
 };
 
 export function parseArgs(args: string[]): ParsedArgs {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -280,12 +280,12 @@ describe('export format', () => {
 // ─── Completions ─────────────────────────────────────────────────────────────
 
 describe('completions', () => {
-  const commands = ['init', 'migrate', 'store', 'recall', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
     'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'purge', 'count', 'namespace', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(25);
+    expect(commands.length).toBe(26);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
     expect(commands).toContain('export');
@@ -922,33 +922,29 @@ describe('field selection flag', () => {
   });
 });
 
-// ─── New flags: ascending ───────────────────────────────────────────────────
+// ─── Search command routing ──────────────────────────────────────────────────
 
-describe('ascending flag', () => {
-  test('--ascending is boolean', () => {
-    const result = parseArgs(['list', '--ascending']);
-    expect(result.ascending).toBe(true);
-    expect(result._).toEqual(['list']);
+describe('search command routing', () => {
+  test('search command extracts query', () => {
+    const args = parseArgs(['search', 'my query', '--json']);
+    const [cmd, ...rest] = args._;
+    expect(cmd).toBe('search');
+    expect(rest[0]).toBe('my query');
+    expect(args.json).toBe(true);
   });
 
-  test('-a short flag for ascending', () => {
-    const result = parseArgs(['list', '-a']);
-    expect(result.ascending).toBe(true);
-  });
-});
-
-// ─── New flags: invert ─────────────────────────────────────────────────────
-
-describe('invert flag', () => {
-  test('--invert is boolean', () => {
-    const result = parseArgs(['list', '--invert']);
-    expect(result.invert).toBe(true);
-    expect(result._).toEqual(['list']);
+  test('search with namespace and limit', () => {
+    const args = parseArgs(['search', 'test', '-n', 'proj', '-l', '5']);
+    const [cmd, ...rest] = args._;
+    expect(cmd).toBe('search');
+    expect(rest[0]).toBe('test');
+    expect(args.namespace).toBe('proj');
+    expect(args.limit).toBe('5');
   });
 
-  test('-I short flag for invert', () => {
-    const result = parseArgs(['list', '-I']);
-    expect(result.invert).toBe(true);
+  test('search with --raw flag', () => {
+    const args = parseArgs(['search', 'query', '--raw']);
+    expect(args.raw).toBe(true);
   });
 });
 


### PR DESCRIPTION
## MEM-84

Adds a `search` command for free text-based search (no embeddings cost).

### Changes
- **New `search` command** — uses `GET /v1/memories/search?q=` for keyword/text matching (free, unlike `recall` which uses vector embeddings)
- **Removed dead code** — `--ascending`/`-a` and `--invert`/`-I` flags were parsed but never used in any command
- **Updated help, completions, and tests**

### Usage
```bash
memoclaw search "meeting notes"
memoclaw search "todo" --namespace work --limit 5
memoclaw search "bug" --raw  # pipe-friendly
```

### Why
`recall` uses semantic vector search ($0.005/call after free tier). `search` uses text matching which is free. Users should have both options.