### PR TITLE
fix: update free tier from 1000 to 100 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MemoClaw CLI
 
-Memory-as-a-Service for AI agents. 1000 free calls per wallet, then x402 micropayments ($0.001/call USDC on Base).
+Memory-as-a-Service for AI agents. 100 free calls per wallet, then x402 micropayments (USDC on Base).
 
 ## Install
 
@@ -140,7 +140,7 @@ memoclaw count  # outputs just the number
 
 ## Free Tier
 
-Every wallet gets **1000 free API calls**. After that, x402 micropayments kick in automatically — $0.001/call in USDC on Base. No signup, no API keys, just your wallet.
+Every wallet gets **100 free API calls**. After that, x402 micropayments kick in automatically (USDC on Base). No signup, no API keys, just your wallet. See [memoclaw.com](https://memoclaw.com) for pricing details.
 
 ## Links
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memoclaw",
   "version": "1.8.5",
-  "description": "MemoClaw CLI - Memory-as-a-Service for AI agents. 1000 free calls, then x402 micropayments.",
+  "description": "MemoClaw CLI - Memory-as-a-Service for AI agents. 100 free calls, then x402 micropayments.",
   "type": "module",
   "bin": {
     "memoclaw": "./dist/cli.mjs"

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -281,11 +281,11 @@ describe('export format', () => {
 
 describe('completions', () => {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
-    'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
+    'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'purge', 'count', 'namespace', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(26);
+    expect(commands.length).toBe(27);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
     expect(commands).toContain('export');


### PR DESCRIPTION
## Changes

- Updated README.md free tier references from 1000 to 100 (intentionally reduced on Feb 15)
- Updated package.json description from 1000 to 100
- Removed incorrect $0.001/call pricing from README (actual pricing varies by operation)
- Added missing `context` command to completions test array (was 26, should be 27)

All 147 tests passing.