### PR TITLE
feat: client-side content length validation (8192 char limit)

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -7,6 +7,8 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, out, success, readStdin } from '../output.js';
 
+const MAX_CONTENT_LENGTH = 8192;
+
 export async function cmdGet(id: string) {
   const result = await request('GET', `/v1/memories/${id}`) as any;
   if (outputJson) {
@@ -36,7 +38,12 @@ export async function cmdDelete(id: string) {
 
 export async function cmdUpdate(id: string, opts: ParsedArgs) {
   const body: Record<string, any> = {};
-  if (opts.content) body.content = opts.content;
+  if (opts.content) {
+    if (String(opts.content).length > MAX_CONTENT_LENGTH) {
+      throw new Error(`Content exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${String(opts.content).length} chars)`);
+    }
+    body.content = opts.content;
+  }
   if (opts.importance != null && opts.importance !== true) body.importance = parseFloat(opts.importance);
   if (opts.memoryType) body.memory_type = opts.memoryType;
   if (opts.namespace) body.namespace = opts.namespace;

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -3,7 +3,16 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, out, success, info } from '../output.js';
 
+const MAX_CONTENT_LENGTH = 8192;
+
+function validateContentLength(content: string, label = 'Content') {
+  if (content.length > MAX_CONTENT_LENGTH) {
+    throw new Error(`${label} exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
+  }
+}
+
 export async function cmdStore(content: string, opts: ParsedArgs) {
+  validateContentLength(content);
   const body: Record<string, any> = { content };
   if (opts.importance != null && opts.importance !== true) body.importance = parseFloat(opts.importance);
   if (opts.tags) body.metadata = { tags: opts.tags.split(',').map((t: string) => t.trim()) };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,33 @@
 import { describe, test, expect } from 'bun:test';
 import { parseArgs, BOOLEAN_FLAGS } from '../src/args';
 
+// ─── Content length validation ───────────────────────────────────────────────
+
+describe('content length validation', () => {
+  const MAX_CONTENT_LENGTH = 8192;
+
+  test('content at limit is accepted', () => {
+    const content = 'a'.repeat(MAX_CONTENT_LENGTH);
+    expect(content.length <= MAX_CONTENT_LENGTH).toBe(true);
+  });
+
+  test('content over limit is rejected', () => {
+    const content = 'a'.repeat(MAX_CONTENT_LENGTH + 1);
+    expect(content.length > MAX_CONTENT_LENGTH).toBe(true);
+  });
+
+  test('error message includes actual length', () => {
+    const content = 'a'.repeat(9000);
+    const msg = `Content exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`;
+    expect(msg).toContain('8192');
+    expect(msg).toContain('9000');
+  });
+
+  test('empty content is within limit', () => {
+    expect(''.length <= MAX_CONTENT_LENGTH).toBe(true);
+  });
+});
+
 // ─── parseArgs ───────────────────────────────────────────────────────────────
 
 describe('parseArgs', () => {


### PR DESCRIPTION
Validates content length before API calls in `store` and `update` commands. Gives clear error message: *exceeds the 8192 character limit (got N chars)*.

Same improvement added to MCP in MEM-116.

- 151 tests pass
- Closes MEM-128