### PR TITLE
feat: add history command to view memory change history

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import { cmdInit, cmdConfig } from './commands/config.js';
 import { cmdMigrate } from './commands/migrate.js';
 import { cmdBrowse } from './commands/browse.js';
 import { cmdCompletions } from './commands/completions.js';
+import { cmdHistory } from './commands/history.js';
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
@@ -161,6 +162,10 @@ try {
       break;
     case 'init':
       await cmdInit(args);
+      break;
+    case 'history':
+      if (!rest[0]) throw new Error('Memory ID required');
+      await cmdHistory(rest[0]);
       break;
     case 'migrate': {
       if (!rest[0]) throw new Error('Path required. Usage: memoclaw migrate <path>');

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,7 +1,7 @@
 export async function cmdCompletions(shell: string) {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
-    'completions', 'config', 'graph', 'purge', 'count', 'namespace', 'help'];
+    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'help'];
 
   const globalFlags = ['--help', '--version', '--json', '--quiet', '--namespace', '--limit', '--offset',
     '--tags', '--format', '--pretty', '--watch', '--raw', '--force', '--output', '--truncate',

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,40 @@
+/**
+ * History command: view change history for a memory
+ */
+
+import { request } from '../http.js';
+import { c } from '../colors.js';
+import { outputJson, out, table } from '../output.js';
+
+export async function cmdHistory(id: string) {
+  const result = await request('GET', `/v1/memories/${id}/history`) as any;
+  if (outputJson) {
+    out(result);
+    return;
+  }
+
+  const history = result.history || [];
+  if (history.length === 0) {
+    console.log(`${c.dim}No history entries found.${c.reset}`);
+    return;
+  }
+
+  const rows = history.map((entry: any) => {
+    const changes = entry.changes || {};
+    const fields = Object.keys(changes).join(', ') || '—';
+    const date = entry.created_at
+      ? new Date(entry.created_at).toLocaleString()
+      : '—';
+    return {
+      id: entry.id?.slice(0, 8) || '?',
+      date,
+      fields,
+    };
+  });
+
+  table(rows, [
+    { key: 'id', label: 'ID', width: 10 },
+    { key: 'date', label: 'DATE', width: 22 },
+    { key: 'fields', label: 'CHANGED FIELDS', width: 40 },
+  ]);
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -263,6 +263,13 @@ Generate shell completion scripts.
   ${c.dim}eval "$(memoclaw completions zsh)"${c.reset}
   ${c.dim}memoclaw completions fish > ~/.config/fish/completions/memoclaw.fish${c.reset}`,
 
+      history: `${c.bold}memoclaw history${c.reset} <id>
+
+View the change history for a memory (FREE).
+
+  ${c.dim}memoclaw history 550e8400-e29b-41d4-a716-446655440000${c.reset}
+  ${c.dim}memoclaw history abc123 --json${c.reset}`,
+
       namespace: `${c.bold}memoclaw namespace${c.reset} [list|stats]
 
 Manage and view namespaces.
@@ -311,6 +318,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}completions${c.reset} <shell>    Generate shell completions
   ${c.cyan}browse${c.reset}                 Interactive memory browser (REPL)
   ${c.cyan}config${c.reset} [show|check]    Show or validate configuration
+  ${c.cyan}history${c.reset} <id>           View change history for a memory
   ${c.cyan}graph${c.reset} <id>             ASCII visualization of memory relations
   ${c.cyan}purge${c.reset}                  Delete ALL memories (requires --force or confirm)
   ${c.cyan}namespace${c.reset} [list|stats] Manage and view namespaces

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -309,10 +309,10 @@ describe('export format', () => {
 describe('completions', () => {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
-    'completions', 'config', 'graph', 'purge', 'count', 'namespace', 'help'];
+    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(27);
+    expect(commands.length).toBe(28);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
     expect(commands).toContain('export');
@@ -403,6 +403,14 @@ describe('BOOLEAN_FLAGS', () => {
 // ─── New commands routing ────────────────────────────────────────────────────
 
 describe('new command routing', () => {
+  test('history command extracts ID', () => {
+    const args = parseArgs(['history', 'abc-123', '--json']);
+    const [cmd, ...rest] = args._;
+    expect(cmd).toBe('history');
+    expect(rest[0]).toBe('abc-123');
+    expect(args.json).toBe(true);
+  });
+
   test('graph command extracts ID', () => {
     const args = parseArgs(['graph', 'abc-123', '--json']);
     const [cmd, ...rest] = args._;


### PR DESCRIPTION
Implements MEM-157.

Adds `memoclaw history <id>` to display the change history for a memory (`GET /v1/memories/:id/history`).

- New `src/commands/history.ts` with table + JSON output
- Wired into CLI router, help text, and shell completions  
- Added tests for command routing and completions count

This is a FREE endpoint (no embeddings cost).