### PR TITLE
refactor: extract shared validators + support stdin for update

### DIFF
--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -2,22 +2,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, out, success, info } from '../output.js';
-
-const MAX_CONTENT_LENGTH = 8192;
-
-function validateContentLength(content: string, label = 'Content') {
-  if (content.length > MAX_CONTENT_LENGTH) {
-    throw new Error(`${label} exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
-  }
-}
-
-function validateImportance(value: string): number {
-  const n = parseFloat(value);
-  if (isNaN(n) || n < 0 || n > 1) {
-    throw new Error(`Importance must be a number between 0 and 1 (got "${value}")`);
-  }
-  return n;
-}
+import { validateContentLength, validateImportance } from '../validate.js';
 
 export async function cmdStore(content: string, opts: ParsedArgs) {
   validateContentLength(content);

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared validation helpers
+ */
+
+export const MAX_CONTENT_LENGTH = 8192;
+
+export function validateContentLength(content: string, label = 'Content') {
+  if (content.length > MAX_CONTENT_LENGTH) {
+    throw new Error(`${label} exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
+  }
+}
+
+export function validateImportance(value: string): number {
+  const n = parseFloat(value);
+  if (isNaN(n) || n < 0 || n > 1) {
+    throw new Error(`Importance must be a number between 0 and 1 (got "${value}")`);
+  }
+  return n;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1174,13 +1174,7 @@ describe('store --content flag', () => {
 // ─── Importance validation ───────────────────────────────────────────────────
 
 describe('importance validation', () => {
-  function validateImportance(value: string): number {
-    const n = parseFloat(value);
-    if (isNaN(n) || n < 0 || n > 1) {
-      throw new Error(`Importance must be a number between 0 and 1 (got "${value}")`);
-    }
-    return n;
-  }
+  const { validateImportance } = require('../src/validate.js') as { validateImportance: (v: string) => number };
 
   test('accepts 0', () => {
     expect(validateImportance('0')).toBe(0);


### PR DESCRIPTION
- Extract `validateImportance`, `validateContentLength`, `MAX_CONTENT_LENGTH` into `src/validate.ts`
- Reuse shared validators in store.ts and memory.ts (removes duplication)
- Add stdin support for update command (`echo 'new' | memoclaw update <id>`)
- Update tests to import from shared validate module

Closes MEM-176, MEM-177