### PR TITLE
test: add 100 integration tests for command handlers (MEM-159)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/setup.ts"]

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -12,18 +12,10 @@
 
 import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
 
-// Set env before any imports that use it
-process.env.MEMOCLAW_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'; // hardhat #0
-process.env.MEMOCLAW_URL = 'http://localhost:99999'; // won't connect, we mock fetch
+// Env vars are set in test/setup.ts via bunfig.toml preload
 
 // Prevent readStdin from blocking (it checks isTTY)
 (process.stdin as any).isTTY = true;
-
-// Prevent process.exit from killing test runner
-const originalExit = process.exit;
-process.exit = ((code?: number) => {
-  throw new Error(`process.exit(${code}) called`);
-}) as any;
 
 // ─── Mock fetch globally ─────────────────────────────────────────────────────
 
@@ -63,7 +55,6 @@ function setupMockFetch() {
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
-  process.exit = originalExit;
   restoreConsole();
 });
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,6 @@
+/**
+ * Test setup: set environment variables before any module loads.
+ * This runs before all test files via bunfig.toml preload.
+ */
+process.env.MEMOCLAW_PRIVATE_KEY = process.env.MEMOCLAW_PRIVATE_KEY || '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+process.env.MEMOCLAW_URL = process.env.MEMOCLAW_URL || 'http://localhost:99999';


### PR DESCRIPTION
Closes MEM-159

Adds 100 integration tests for all command handlers with mocked fetch layer. Total suite: 316 tests.

**Commands covered:** store, recall, list, search, get, delete, update, count, history, relations, context, extract, ingest, consolidate, suggested, graph, namespace, validate

**Strategy:** Mock globalThis.fetch, capture console output, test text+JSON modes, verify requests and error paths.