### PR TITLE
feat: add --format csv/tsv output for list and recall (MEM-178)

### DIFF
--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -1,7 +1,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, out, truncate } from '../output.js';
+import { outputJson, outputTruncate, outputFormat, out, truncate } from '../output.js';
 
 export async function cmdRecall(query: string, opts: ParsedArgs) {
   const body: Record<string, any> = { query };
@@ -54,6 +54,16 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
 
   if (outputJson) {
     out(result);
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const memories = result.memories || [];
+    const rows = memories.map((m: any) => ({
+      id: m.id || '',
+      similarity: m.similarity?.toFixed(3) || '',
+      content: m.content || '',
+      importance: m.importance?.toFixed(2) || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+    }));
+    out(rows);
   } else if (opts.raw) {
     const memories = result.memories || [];
     for (const mem of memories) {


### PR DESCRIPTION
Adds `--format csv` and `--format tsv` output support for `list` and `recall` commands.

### Changes
- Added `tsv` to the `outputFormat` union type
- `out()` now handles TSV with tab separators, escaping tabs/newlines in values
- `table()` routes `tsv` format through `out()` like `csv`
- `recall` command now supports `csv`, `tsv`, and `yaml` format output

### Usage
```bash
memoclaw list --format csv
memoclaw list --format tsv
memoclaw recall "query" --format csv
memoclaw recall "query" -f tsv
```

Fixes MEM-178