### PR TITLE
fix: improve help text and error messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,22 +74,22 @@ try {
       break;
     }
     case 'recall':
-      if (!rest[0]) throw new Error('Query required');
+      if (!rest[0]) throw new Error('Query required. Usage: memoclaw recall "search query"');
       await cmdRecall(rest[0], args);
       break;
     case 'list':
       await cmdList(args);
       break;
     case 'get':
-      if (!rest[0]) throw new Error('Memory ID required');
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw get <id>');
       await cmdGet(rest[0]);
       break;
     case 'update':
-      if (!rest[0]) throw new Error('Memory ID required');
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw update <id> --content "new text"');
       await cmdUpdate(rest[0], args);
       break;
     case 'delete':
-      if (!rest[0]) throw new Error('Memory ID required');
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw delete <id>');
       await cmdDelete(rest[0]);
       break;
     case 'ingest':
@@ -106,11 +106,11 @@ try {
       break;
     }
     case 'search':
-      if (!rest[0]) throw new Error('Query required');
+      if (!rest[0]) throw new Error('Query required. Usage: memoclaw search "keyword"');
       await cmdSearch(rest[0], args);
       break;
     case 'context':
-      if (!rest[0]) throw new Error('Query required');
+      if (!rest[0]) throw new Error('Query required. Usage: memoclaw context "what do I know about X?"');
       await cmdContext(rest[0], args);
       break;
     case 'consolidate':
@@ -118,7 +118,7 @@ try {
       break;
     case 'relations': {
       const subcmd = rest[0];
-      if (!subcmd) throw new Error('Usage: relations [list|create|delete]');
+      if (!subcmd) throw new Error('Subcommand required. Usage: memoclaw relations <list|create|delete> <memory-id>');
       await cmdRelations(subcmd, rest.slice(1), args);
       break;
     }
@@ -138,7 +138,7 @@ try {
       await cmdStats(args);
       break;
     case 'completions':
-      if (!rest[0]) throw new Error('Shell required: bash, zsh, or fish');
+      if (!rest[0]) throw new Error('Shell required. Usage: memoclaw completions <bash|zsh|fish>');
       await cmdCompletions(rest[0]);
       break;
     case 'browse':
@@ -148,7 +148,7 @@ try {
       await cmdConfig(rest[0], rest.slice(1));
       break;
     case 'graph':
-      if (!rest[0]) throw new Error('Memory ID required');
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw graph <id>');
       await cmdGraph(rest[0], args);
       break;
     case 'purge':
@@ -164,7 +164,7 @@ try {
       await cmdInit(args);
       break;
     case 'history':
-      if (!rest[0]) throw new Error('Memory ID required');
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw history <id>');
       await cmdHistory(rest[0]);
       break;
     case 'migrate': {

--- a/src/help.ts
+++ b/src/help.ts
@@ -55,7 +55,10 @@ Options:
   --limit <n>            Max results (default: 10)
   --min-similarity <0-1> Similarity threshold (default: 0.5)
   --namespace <name>     Filter by namespace
-  --tags <tag1,tag2>     Filter by tags`,
+  --tags <tag1,tag2>     Filter by tags
+  --raw                  Output content only (for piping)
+  --watch                Watch for changes (continuous polling)
+  --watch-interval <ms>  Polling interval (default: 5000)`,
 
       list: `${c.bold}memoclaw list${c.reset} [options]
 
@@ -67,7 +70,10 @@ Options:
   --namespace <name>     Filter by namespace
   --sort-by <field>      Sort by field (id, importance, created, updated)
   --reverse              Reverse sort order
-  --columns <cols>       Select columns (id,content,importance,tags,created)`,
+  --columns <cols>       Select columns (id,content,importance,tags,created)
+  --wide                 Use wider columns in table output
+  --watch                Watch for changes (continuous polling)
+  --watch-interval <ms>  Polling interval (default: 5000)`,
 
       export: `${c.bold}memoclaw export${c.reset} [options]
 
@@ -102,13 +108,15 @@ Options:
 
 Retrieve a single memory by its ID.`,
 
-      config: `${c.bold}memoclaw config${c.reset} [show|check]
+      config: `${c.bold}memoclaw config${c.reset} [show|check|init|path]
 
 Show or validate your MemoClaw configuration.
 
 Subcommands:
   show       Display current configuration (default)
-  check      Validate configuration and test connectivity`,
+  check      Validate configuration and test connectivity
+  init       Create a sample YAML config file at ~/.memoclaw/config
+  path       Print the config file path`,
 
       update: `${c.bold}memoclaw update${c.reset} <id> [options]
 


### PR DESCRIPTION
## Changes

- Add missing `--raw` and `--watch` options to `recall` help text
- Add missing `--wide` and `--watch` options to `list` help text
- Document `config init` and `config path` subcommands in help
- Add usage hints to all error messages (e.g. `Memory ID required. Usage: memoclaw get <id>`)
- Improve `relations` error message with proper usage format

All tests pass (316/316).