### PR TITLE
feat: add bulk-delete command, --memory-type for store, --file for ingest

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { printHelp } from './help.js';
 import { cmdStore } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
-import { cmdGet, cmdDelete, cmdUpdate } from './commands/memory.js';
+import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } from './commands/memory.js';
 import { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } from './commands/search.js';
 import { cmdRelations } from './commands/relations.js';
 import { cmdStatus, cmdStats, cmdCount, cmdSuggested, cmdGraph } from './commands/status.js';
@@ -92,6 +92,16 @@ try {
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw delete <id>');
       await cmdDelete(rest[0]);
       break;
+    case 'bulk-delete': {
+      let ids = rest;
+      if (ids.length === 0) {
+        const stdin = await readStdin();
+        if (stdin) ids = stdin.split(/[\n,\s]+/).map(s => s.trim()).filter(Boolean);
+      }
+      if (ids.length === 0) throw new Error('Memory IDs required. Usage: memoclaw bulk-delete <id1> <id2> ...');
+      await cmdBulkDelete(ids, args);
+      break;
+    }
     case 'ingest':
       await cmdIngest(args);
       break;

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,5 +1,5 @@
 export async function cmdCompletions(shell: string) {
-  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'help'];
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -36,6 +36,16 @@ export async function cmdDelete(id: string) {
   }
 }
 
+export async function cmdBulkDelete(ids: string[], opts: ParsedArgs) {
+  const result = await request('POST', '/v1/memories/bulk-delete', { ids }) as any;
+  if (outputJson) {
+    out(result);
+  } else {
+    const deleted = result.deleted ?? ids.length;
+    success(`Deleted ${c.cyan}${deleted}${c.reset} memories`);
+  }
+}
+
 export async function cmdUpdate(id: string, opts: ParsedArgs) {
   const body: Record<string, any> = {};
   let content = opts.content && opts.content !== true ? String(opts.content) : undefined;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -78,12 +78,18 @@ export async function cmdIngest(opts: ParsedArgs) {
   if (opts.autoRelate !== undefined) body.auto_relate = opts.autoRelate !== 'false';
   else body.auto_relate = true;
 
+  if (!body.text && opts.file) {
+    const fs = await import('fs');
+    if (!fs.existsSync(opts.file)) throw new Error(`File not found: ${opts.file}`);
+    body.text = fs.readFileSync(opts.file, 'utf-8');
+  }
+
   if (!body.text) {
     const stdin = await readStdin();
     if (stdin) body.text = stdin;
   }
 
-  if (!body.text) throw new Error('Text required (use --text or pipe via stdin)');
+  if (!body.text) throw new Error('Text required (use --text, --file, or pipe via stdin)');
 
   const result = await request('POST', '/v1/ingest', body) as any;
   if (outputJson) {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -10,6 +10,7 @@ export async function cmdStore(content: string, opts: ParsedArgs) {
   if (opts.importance != null && opts.importance !== true) body.importance = validateImportance(opts.importance);
   if (opts.tags) body.metadata = { tags: opts.tags.split(',').map((t: string) => t.trim()) };
   if (opts.namespace) body.namespace = opts.namespace;
+  if (opts.memoryType) body.memory_type = opts.memoryType;
   if (opts.immutable) body.immutable = true;
   if (opts.pinned) body.pinned = true;
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -22,6 +22,7 @@ Options:
   --importance <0-1>     Importance score (default: 0.5)
   --tags <tag1,tag2>     Comma-separated tags
   --namespace <name>     Memory namespace
+  --memory-type <type>   Memory type (e.g. core, episodic, semantic)
   --immutable            Lock memory from future modifications
   --pinned               Pin the memory`,
 
@@ -140,6 +141,15 @@ Delete a memory by ID.
 
   ${c.dim}memoclaw delete abc123${c.reset}`,
 
+      'bulk-delete': `${c.bold}memoclaw bulk-delete${c.reset} <id1> <id2> ...
+
+Delete multiple memories at once. IDs can be provided as arguments
+or piped via stdin (newline, comma, or space-separated).
+
+  ${c.dim}memoclaw bulk-delete abc123 def456 ghi789${c.reset}
+  ${c.dim}echo "abc123,def456" | memoclaw bulk-delete${c.reset}
+  ${c.dim}memoclaw list --json | jq -r '.memories[].id' | memoclaw bulk-delete${c.reset}`,
+
       ingest: `${c.bold}memoclaw ingest${c.reset} [options]
 
 Ingest raw text and automatically extract memories from it.
@@ -147,9 +157,11 @@ Uses GPT-4o-mini + embeddings. Costs $0.01 per call.
 
   ${c.dim}echo "Meeting notes..." | memoclaw ingest${c.reset}
   ${c.dim}memoclaw ingest --text "Long text to extract memories from"${c.reset}
+  ${c.dim}memoclaw ingest --file meeting-notes.txt${c.reset}
 
 Options:
   --text <text>          Text to ingest (or pipe via stdin)
+  --file <path>          Read text from a file
   --namespace <name>     Target namespace
   --session-id <id>      Session identifier
   --agent-id <id>        Agent identifier
@@ -313,6 +325,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}get${c.reset} <id>               Get a single memory by ID
   ${c.cyan}update${c.reset} <id>            Update a memory
   ${c.cyan}delete${c.reset} <id>            Delete a memory
+  ${c.cyan}bulk-delete${c.reset} <ids>       Delete multiple memories at once
   ${c.cyan}ingest${c.reset}                 Ingest raw text into memories
   ${c.cyan}extract${c.reset} "text"         Extract memories from text
   ${c.cyan}context${c.reset} "query"        Get GPT-powered contextual summary ($0.01/call)


### PR DESCRIPTION
## Changes

### New: `bulk-delete` command
Delete multiple memories at once. IDs can be passed as arguments or piped via stdin:
```bash
memoclaw bulk-delete abc123 def456 ghi789
echo "abc123,def456" | memoclaw bulk-delete
memoclaw list --json | jq -r '.memories[].id' | memoclaw bulk-delete
```

### New: `--memory-type` flag for `store`
Consistency fix — `update` already supports `--memory-type`, now `store` does too:
```bash
memoclaw store "Important fact" --memory-type core
```

### New: `--file` flag for `ingest`
Read text from a file instead of requiring `--text` or stdin:
```bash
memoclaw ingest --file meeting-notes.txt
```

All existing tests pass (316/316).