### PR TITLE
feat: add --session-id, --agent-id, --expires-at flags to store command

### DIFF
--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -13,6 +13,9 @@ export async function cmdStore(content: string, opts: ParsedArgs) {
   if (opts.memoryType) body.memory_type = opts.memoryType;
   if (opts.immutable) body.immutable = true;
   if (opts.pinned) body.pinned = true;
+  if (opts.sessionId) body.session_id = opts.sessionId;
+  if (opts.agentId) body.agent_id = opts.agentId;
+  if (opts.expiresAt) body.expires_at = opts.expiresAt;
 
   const result = await request('POST', '/v1/store', body);
   if (outputJson) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -24,7 +24,10 @@ Options:
   --namespace <name>     Memory namespace
   --memory-type <type>   Memory type (e.g. core, episodic, semantic)
   --immutable            Lock memory from future modifications
-  --pinned               Pin the memory`,
+  --pinned               Pin the memory
+  --session-id <id>      Session identifier for tracking
+  --agent-id <id>        Agent identifier for multi-agent setups
+  --expires-at <date>    Expiration date (ISO 8601)`,
 
       search: `${c.bold}memoclaw search${c.reset} "query" [options]
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -201,6 +201,16 @@ describe('cmdStore', () => {
     expect(body.namespace).toBeUndefined();
     restoreConsole();
   });
+
+  test('passes session-id, agent-id, and expires-at', async () => {
+    mockFetchResponse = { id: 'abc-123' };
+    await cmdStore('test', { _: [], sessionId: 'sess-1', agentId: 'agent-1', expiresAt: '2026-12-31T00:00:00Z' } as any);
+    const body = getLastBody();
+    expect(body.session_id).toBe('sess-1');
+    expect(body.agent_id).toBe('agent-1');
+    expect(body.expires_at).toBe('2026-12-31T00:00:00Z');
+    restoreConsole();
+  });
 });
 
 // ─── Recall ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds three missing flags to the `store` command that the API already supports:

- `--session-id <id>` — Session identifier for tracking memory context
- `--agent-id <id>` — Agent identifier for multi-agent setups  
- `--expires-at <date>` — Expiration date (ISO 8601) for temporary memories

These were already handled in the `import` command but weren't exposed in `store`. Useful for OpenClaw agents that need session tracking or temporary memories.

**Changes:**
- `src/commands/store.ts` — pass through the three new fields
- `src/help.ts` — document the new flags
- `test/commands.test.ts` — add test for the new flags

All 317 tests pass.