### PR TITLE
fix: reject empty/whitespace-only content in store, update, and extract

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -6,7 +6,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, out, success, readStdin } from '../output.js';
-import { MAX_CONTENT_LENGTH, validateImportance } from '../validate.js';
+import { MAX_CONTENT_LENGTH, validateContentLength, validateImportance } from '../validate.js';
 
 export async function cmdGet(id: string) {
   const result = await request('GET', `/v1/memories/${id}`) as any;
@@ -54,9 +54,7 @@ export async function cmdUpdate(id: string, opts: ParsedArgs) {
     if (stdin) content = stdin;
   }
   if (content) {
-    if (content.length > MAX_CONTENT_LENGTH) {
-      throw new Error(`Content exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
-    }
+    validateContentLength(content);
     body.content = content;
   }
   if (opts.importance != null && opts.importance !== true) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,6 +5,9 @@
 export const MAX_CONTENT_LENGTH = 8192;
 
 export function validateContentLength(content: string, label = 'Content') {
+  if (!content.trim()) {
+    throw new Error(`${label} cannot be empty or whitespace-only`);
+  }
   if (content.length > MAX_CONTENT_LENGTH) {
     throw new Error(`${label} exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
   }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -970,8 +970,12 @@ describe('validateContentLength', () => {
     expect(() => validateContentLength('x'.repeat(8193), 'Update')).toThrow('Update');
   });
 
-  test('allows empty content', () => {
-    expect(() => validateContentLength('')).not.toThrow();
+  test('rejects empty content', () => {
+    expect(() => validateContentLength('')).toThrow('empty');
+  });
+
+  test('rejects whitespace-only content', () => {
+    expect(() => validateContentLength('   \n\t  ')).toThrow('empty');
   });
 });
 


### PR DESCRIPTION
Previously, empty strings passed `validateContentLength`, allowing useless memories to be stored. Now rejects empty or whitespace-only content with a clear error message.

- `validateContentLength` checks for empty/whitespace-only strings
- `cmdUpdate` uses `validateContentLength` instead of inline length check (DRY)
- Updated tests (318 pass)