### PR TITLE
fix: clamp progress bar values in status command

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -47,9 +47,9 @@ export async function cmdStatus() {
       console.log(`${c.bold}Wallet:${c.reset}     ${data.wallet}`);
       const remaining = data.free_tier_remaining ?? 0;
       const total = data.free_tier_total ?? 100;
-      const pct = Math.round((remaining / total) * 100);
+      const pct = Math.max(0, Math.min(100, Math.round((remaining / total) * 100)));
       const barLen = 20;
-      const filled = Math.round((remaining / total) * barLen);
+      const filled = Math.max(0, Math.min(barLen, Math.round((remaining / total) * barLen)));
       const bar = `${c.green}${'█'.repeat(filled)}${c.dim}${'░'.repeat(barLen - filled)}${c.reset}`;
       console.log(`${c.bold}Free tier:${c.reset}  ${remaining}/${total} calls remaining`);
       console.log(`            ${bar} ${pct}%`);


### PR DESCRIPTION
## Problem

When `free_tier_remaining` exceeds `free_tier_total` (e.g. server returns remaining=9926, total=100), the progress bar calculation produces negative repeat counts, crashing `memoclaw status` with `Invalid count value: -1965`.

## Fix

Clamp `filled` to `[0, barLen]` and `pct` to `[0, 100]`.

## Testing

All 321 tests pass. Verified against production.