### PR TITLE
fix: apply namespace and timeout from config file and env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoclaw",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoclaw",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "license": "MIT",
       "dependencies": {
         "@x402/core": "^2.3.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@
  */
 
 import { parseArgs } from './args.js';
-import { VERSION } from './config.js';
+import { VERSION, DEFAULT_NAMESPACE, DEFAULT_TIMEOUT } from './config.js';
 import { c } from './colors.js';
 import { configureOutput, outputJson, readStdin } from './output.js';
 import { setRequestTimeout } from './http.js';
@@ -57,8 +57,11 @@ if (args.help) {
   process.exit(0);
 }
 
+// Apply config-file / env-var defaults
+if (!args.namespace && DEFAULT_NAMESPACE) args.namespace = DEFAULT_NAMESPACE;
+
 // Configure request timeout
-const TIMEOUT_MS = args.timeout ? parseInt(args.timeout) * 1000 : 30000;
+const TIMEOUT_MS = args.timeout ? parseInt(args.timeout) * 1000 : DEFAULT_TIMEOUT * 1000;
 setRequestTimeout(TIMEOUT_MS);
 
 try {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 import { privateKeyToAccount } from 'viem/accounts';
 import type { ParsedArgs } from '../args.js';
 import { c } from '../colors.js';
-import { API_URL, PRIVATE_KEY, CONFIG_DIR, CONFIG_FILE, CONFIG_FILE_JSON, ensureConfigDir } from '../config.js';
+import { API_URL, PRIVATE_KEY, DEFAULT_NAMESPACE, DEFAULT_TIMEOUT, CONFIG_DIR, CONFIG_FILE, CONFIG_FILE_JSON, ensureConfigDir } from '../config.js';
 import { getAccount } from '../auth.js';
 import { outputJson, out, success, info } from '../output.js';
 
@@ -82,6 +82,8 @@ export async function cmdConfig(subcmd: string, rest: string[]) {
     const config: Record<string, string> = {
       MEMOCLAW_URL: API_URL,
       MEMOCLAW_PRIVATE_KEY: PRIVATE_KEY ? `${PRIVATE_KEY.slice(0, 6)}…${PRIVATE_KEY.slice(-4)}` : '(not set)',
+      MEMOCLAW_NAMESPACE: DEFAULT_NAMESPACE || '(not set)',
+      MEMOCLAW_TIMEOUT: `${DEFAULT_TIMEOUT}s`,
       NO_COLOR: process.env.NO_COLOR || '(not set)',
       DEBUG: process.env.DEBUG || '(not set)',
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,3 +65,5 @@ const _fileConfig = loadConfigFile();
 
 export const API_URL = process.env.MEMOCLAW_URL || _persistedConfig.url || _fileConfig.url || 'https://api.memoclaw.com';
 export const PRIVATE_KEY = (process.env.MEMOCLAW_PRIVATE_KEY || _persistedConfig.privateKey || _fileConfig.privateKey) as `0x${string}`;
+export const DEFAULT_NAMESPACE: string | undefined = process.env.MEMOCLAW_NAMESPACE || _fileConfig.namespace || undefined;
+export const DEFAULT_TIMEOUT: number = process.env.MEMOCLAW_TIMEOUT ? parseInt(process.env.MEMOCLAW_TIMEOUT) : (_fileConfig.timeout ?? 30);


### PR DESCRIPTION
## Problem

`memoclaw config init` generates a YAML config with `namespace` and `timeout` fields, and references `MEMOCLAW_NAMESPACE`/`MEMOCLAW_TIMEOUT` env vars — but none of these were actually read or applied.

Users setting `namespace: myproject` in `~/.memoclaw/config` would see it silently ignored.

## Fix

- Export `DEFAULT_NAMESPACE` and `DEFAULT_TIMEOUT` from `config.ts` using the same cascade (env var → config file → default)
- Apply them in `cli.ts` as defaults (still overridable via `--namespace`/`--timeout` flags)
- Show them in `memoclaw config show`

## Testing

All 321 tests pass. Build succeeds.