### PR TITLE
fix: namespace stats double-fetch and add immutable flag to update

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -65,6 +65,7 @@ export async function cmdUpdate(id: string, opts: ParsedArgs) {
   if (opts.tags) body.metadata = { tags: opts.tags.split(',').map((t: string) => t.trim()) };
   if (opts.expiresAt) body.expires_at = opts.expiresAt;
   if (opts.pinned !== undefined) body.pinned = opts.pinned === 'true' || opts.pinned === true;
+  if (opts.immutable !== undefined) body.immutable = opts.immutable === 'true' || opts.immutable === true;
 
   if (Object.keys(body).length === 0) {
     throw new Error('No fields to update. Use --content, --importance, --tags, etc.');

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -62,13 +62,8 @@ export async function cmdNamespace(subcmd: string, rest: string[], opts: ParsedA
 
     if (hasNoCounts) {
       // API returned names only, need to fetch memories for counts
-      const fallback = await fetchNamespacesFromMemories();
-      const countMap = new Map(fallback.map(ns => [ns.name, ns.count]));
-      // Include default namespace count
-      const allNs = await fetchNamespacesFromMemories();
-      rows = [
-        ...allNs.map(ns => ({ namespace: ns.name || '(default)', count: String(ns.count) }))
-      ];
+      const withCounts = await fetchNamespacesFromMemories();
+      rows = withCounts.map(ns => ({ namespace: ns.name || '(default)', count: String(ns.count) }));
     } else {
       rows = namespaces.map(ns => ({ namespace: ns.name || '(default)', count: String(ns.count) }));
     }


### PR DESCRIPTION
## Changes

### 1. Fix namespace stats double-fetch (bug)
In `cmdNamespace stats`, when the API returns namespace names without counts, `fetchNamespacesFromMemories()` was called **twice** — once as `fallback` (never used) and once as `allNs`. The `countMap` variable was also computed but never referenced. This doubled API calls unnecessarily.

**Fix:** Single call, removed dead variables.

### 2. Add `--immutable` flag to update command (missing feature)
The `store` command supported `--immutable` but `update` did not, making it impossible to toggle immutability on existing memories via CLI.

**Fix:** Added `opts.immutable` handling to `cmdUpdate`.

---
All 321 tests pass. Build succeeds.