### PR TITLE
feat: add --batch flag to store command for piping multiple memories

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -11,7 +11,7 @@ export interface ParsedArgs {
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
   'force', 'count', 'wide', 'pretty', 'watch', 'interactive', 'yes', 'reverse',
-  'noTruncate', 'immutable', 'pinned',
+  'noTruncate', 'immutable', 'pinned', 'batch',
 ]);
 
 /** Short flag aliases */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { setRequestTimeout } from './http.js';
 import { printHelp } from './help.js';
 
 // Commands
-import { cmdStore } from './commands/store.js';
+import { cmdStore, cmdStoreBatch } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
 import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } from './commands/memory.js';
@@ -67,6 +67,12 @@ setRequestTimeout(TIMEOUT_MS);
 try {
   switch (cmd) {
     case 'store': {
+      if (args.batch) {
+        const stdin = await readStdin();
+        const lines = stdin ? stdin.split('\n') : [];
+        await cmdStoreBatch(args, lines);
+        break;
+      }
       let content = rest[0] || (args.content && args.content !== true ? args.content : undefined);
       if (!content) {
         const stdin = await readStdin();

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -1,8 +1,68 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, out, success, info } from '../output.js';
+import { outputJson, outputQuiet, out, success, info, progressBar } from '../output.js';
 import { validateContentLength, validateImportance } from '../validate.js';
+
+export async function cmdStoreBatch(opts: ParsedArgs, lines: string[]) {
+  if (lines.length === 0) throw new Error('No input. Pipe content via stdin (one memory per line, or JSON array).');
+
+  // Try parsing as JSON array first
+  let memories: { content: string; [k: string]: any }[];
+  const joined = lines.join('\n').trim();
+  if (joined.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(joined);
+      if (!Array.isArray(parsed)) throw new Error('Expected JSON array');
+      memories = parsed.map((item: any) => {
+        if (typeof item === 'string') return { content: item };
+        if (typeof item === 'object' && item.content) return item;
+        throw new Error('Each array element must be a string or object with "content" field');
+      });
+    } catch (e: any) {
+      throw new Error(`Invalid JSON array: ${e.message}`);
+    }
+  } else {
+    // One memory per line
+    memories = lines.filter(l => l.trim()).map(l => ({ content: l.trim() }));
+  }
+
+  if (memories.length === 0) throw new Error('No memories to store');
+
+  // Apply shared opts to each memory
+  for (const mem of memories) {
+    validateContentLength(mem.content);
+    if (opts.importance != null && opts.importance !== true && mem.importance === undefined)
+      mem.importance = validateImportance(opts.importance);
+    if (opts.tags && !mem.metadata)
+      mem.metadata = { tags: opts.tags.split(',').map((t: string) => t.trim()) };
+    if (opts.namespace && !mem.namespace) mem.namespace = opts.namespace;
+    if (opts.memoryType && !mem.memory_type) mem.memory_type = opts.memoryType;
+    if (opts.immutable && mem.immutable === undefined) mem.immutable = true;
+    if (opts.pinned && mem.pinned === undefined) mem.pinned = true;
+  }
+
+  // Batch in chunks of 100
+  const BATCH_SIZE = 100;
+  let stored = 0;
+
+  for (let i = 0; i < memories.length; i += BATCH_SIZE) {
+    const chunk = memories.slice(i, i + BATCH_SIZE);
+    const result = await request('POST', '/v1/store/batch', { memories: chunk }) as any;
+    stored += result.stored ?? chunk.length;
+    if (!outputQuiet) {
+      process.stderr.write(`\r  ${progressBar(Math.min(i + BATCH_SIZE, memories.length), memories.length)}`);
+    }
+  }
+
+  if (!outputQuiet) process.stderr.write('\n');
+
+  if (outputJson) {
+    out({ stored, total: memories.length });
+  } else {
+    success(`Stored ${c.cyan}${stored}${c.reset} memories via batch`);
+  }
+}
 
 export async function cmdStore(content: string, opts: ParsedArgs) {
   validateContentLength(content);

--- a/src/help.ts
+++ b/src/help.ts
@@ -17,7 +17,13 @@ via --content flag, or piped via stdin.
   ${c.dim}memoclaw store --content "Hello world"${c.reset}
   ${c.dim}echo "Hello world" | memoclaw store${c.reset}
 
+Batch mode (pipe multiple memories):
+  ${c.dim}echo -e "memory one\\nmemory two" | memoclaw store --batch${c.reset}
+  ${c.dim}echo '["first","second"]' | memoclaw store --batch${c.reset}
+  ${c.dim}cat memories.json | memoclaw store --batch${c.reset}  (JSON array of objects)
+
 Options:
+  --batch                Read multiple memories from stdin (one per line or JSON array)
   --content <text>       Memory content (alternative to positional arg)
   --importance <0-1>     Importance score (default: 0.5)
   --tags <tag1,tag2>     Comma-separated tags


### PR DESCRIPTION
## What

Adds a `--batch` flag to `memoclaw store` that reads multiple memories from stdin and stores them via the batch endpoint.

## Why

Currently batch-storing requires `memoclaw import` with a full JSON export structure. This is cumbersome for simple use cases like piping a list of memories.

## How

- New `cmdStoreBatch()` in `src/commands/store.ts`
- Accepts one-per-line text OR JSON arrays (strings or objects with `content` field)
- Uses `/v1/store/batch` endpoint, chunked in batches of 100
- Shared flags (`--namespace`, `--tags`, `--importance`, `--immutable`, `--pinned`) applied to all memories
- 6 new tests added

## Examples

```bash
echo -e 'memory one\nmemory two' | memoclaw store --batch
echo '["first","second"]' | memoclaw store --batch
echo '[{"content":"hello","importance":0.9}]' | memoclaw store --batch
```