### PR TITLE
feat: add --raw flag to get command for pipe-friendly output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { cmdStore, cmdStoreBatch } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
 import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } from './commands/memory.js';
+
 import { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } from './commands/search.js';
 import { cmdRelations } from './commands/relations.js';
 import { cmdStatus, cmdStats, cmdCount, cmdSuggested, cmdGraph } from './commands/status.js';
@@ -91,7 +92,7 @@ try {
       break;
     case 'get':
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw get <id>');
-      await cmdGet(rest[0]);
+      await cmdGet(rest[0], args);
       break;
     case 'update':
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw update <id> --content "new text"');

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -8,10 +8,13 @@ import { c } from '../colors.js';
 import { outputJson, out, success, readStdin } from '../output.js';
 import { MAX_CONTENT_LENGTH, validateContentLength, validateImportance } from '../validate.js';
 
-export async function cmdGet(id: string) {
+export async function cmdGet(id: string, opts?: ParsedArgs) {
   const result = await request('GET', `/v1/memories/${id}`) as any;
   if (outputJson) {
     out(result);
+  } else if (opts?.raw) {
+    const mem = result.memory || result;
+    console.log(mem.content);
   } else {
     const mem = result.memory || result;
     console.log(`${c.bold}ID:${c.reset}         ${mem.id || id}`);

--- a/src/help.ts
+++ b/src/help.ts
@@ -117,10 +117,17 @@ Show memory statistics and account info.
 Options:
   --namespace <name>     Filter by namespace`,
 
-      get: `${c.bold}memoclaw get${c.reset} <id>
+      get: `${c.bold}memoclaw get${c.reset} <id> [options]
 
 Retrieve a single memory by its ID.
-Shows all fields including importance, tags, type, expiry, session/agent IDs.`,
+Shows all fields including importance, tags, type, expiry, session/agent IDs.
+
+  ${c.dim}memoclaw get abc123${c.reset}
+  ${c.dim}memoclaw get abc123 --raw | wc -c${c.reset}
+  ${c.dim}memoclaw get abc123 --raw | memoclaw update abc123${c.reset}
+
+Options:
+  --raw                  Output content only (for piping)`,
 
       config: `${c.bold}memoclaw config${c.reset} [show|check|init|path]
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -528,6 +528,13 @@ describe('cmdGet', () => {
     restoreConsole();
   });
 
+  test('outputs raw content with --raw', async () => {
+    mockFetchResponse = { id: 'abc-123', content: 'just the content' };
+    await cmdGet('abc-123', { _: [], raw: true } as any);
+    expect(consoleOutput).toEqual(['just the content']);
+    restoreConsole();
+  });
+
   test('handles nested memory object', async () => {
     mockFetchResponse = { memory: { id: 'x', content: 'nested' } };
     await cmdGet('x');


### PR DESCRIPTION
## What

Adds `--raw` flag to `memoclaw get` command, outputting only the memory content (no formatting, no labels).

## Why

`recall` and `search` already support `--raw`, but `get` didn't. This made it impossible to pipe a specific memory's content into other commands.

## Examples

```bash
# Get just the content
memoclaw get abc123 --raw

# Pipe into word count
memoclaw get abc123 --raw | wc -c

# Read, transform, write back
memoclaw get abc123 --raw | sed 's/old/new/g' | memoclaw update abc123
```

## Changes

- `src/commands/memory.ts`: Added optional `opts` param to `cmdGet`, handles `--raw`
- `src/cli.ts`: Pass `args` to `cmdGet`
- `src/help.ts`: Updated help text for `get` command
- `test/commands.test.ts`: Added test for `--raw` output

All 343 tests pass.