### PR TITLE
fix: sort-by created/updated maps to created_at/updated_at fields

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -75,12 +75,18 @@ export async function cmdList(opts: ParsedArgs) {
     // Client-side sorting
     if (opts.sortBy && memories.length > 0) {
       const sortKey = opts.sortBy;
+      // Map user-friendly sort keys to actual API field names
+      const sortKeyMap: Record<string, string> = {
+        created: 'created_at',
+        updated: 'updated_at',
+      };
+      const resolvedKey = sortKeyMap[sortKey] || sortKey;
       const reverse = !!opts.reverse;
       memories = [...memories].sort((a: any, b: any) => {
-        let aVal = a[sortKey];
-        let bVal = b[sortKey];
-        if (aVal === undefined && sortKey.includes('.')) {
-          const parts = sortKey.split('.');
+        let aVal = a[resolvedKey];
+        let bVal = b[resolvedKey];
+        if (aVal === undefined && resolvedKey.includes('.')) {
+          const parts = resolvedKey.split('.');
           let obj: any = a;
           for (const p of parts) obj = obj?.[p];
           aVal = obj;
@@ -92,7 +98,7 @@ export async function cmdList(opts: ParsedArgs) {
           aVal = new Date(aVal).getTime();
           bVal = new Date(bVal as string).getTime();
         }
-        if (sortKey === 'importance') {
+        if (resolvedKey === 'importance') {
           aVal = parseFloat(aVal) || 0;
           bVal = parseFloat(bVal) || 0;
         }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -419,6 +419,38 @@ describe('cmdList', () => {
     restoreConsole();
   });
 
+  test('client-side sorting by created maps to created_at', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'a', content: 'newer', importance: 0.5, metadata: {}, created_at: '2026-03-01T12:00:00Z' },
+        { id: 'b', content: 'older', importance: 0.5, metadata: {}, created_at: '2026-01-01T12:00:00Z' },
+      ],
+      total: 2
+    };
+    await cmdList({ _: [], sortBy: 'created' } as any);
+    const output = consoleOutput.join('\n');
+    const olderIdx = output.indexOf('older');
+    const newerIdx = output.indexOf('newer');
+    expect(olderIdx).toBeLessThan(newerIdx);
+    restoreConsole();
+  });
+
+  test('client-side sorting by updated maps to updated_at', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'a', content: 'recent', importance: 0.5, metadata: {}, updated_at: '2026-03-01T12:00:00Z' },
+        { id: 'b', content: 'stale', importance: 0.5, metadata: {}, updated_at: '2026-01-01T12:00:00Z' },
+      ],
+      total: 2
+    };
+    await cmdList({ _: [], sortBy: 'updated' } as any);
+    const output = consoleOutput.join('\n');
+    const staleIdx = output.indexOf('stale');
+    const recentIdx = output.indexOf('recent');
+    expect(staleIdx).toBeLessThan(recentIdx);
+    restoreConsole();
+  });
+
   test('passes tags query param', async () => {
     mockFetchResponse = { memories: [], total: 0 };
     await cmdList({ _: [], tags: 'foo,bar' } as any);


### PR DESCRIPTION
The list command's client-side sorting by `created` or `updated` was silently failing because the API returns these fields as `created_at` and `updated_at`.

Added a key mapping so `--sort-by created` and `--sort-by updated` work as documented in help text.

**Changes:**
- `src/commands/list.ts`: Added `sortKeyMap` to resolve `created` → `created_at` and `updated` → `updated_at`
- `test/commands.test.ts`: Added 2 tests for sorting by created and updated

All 349 tests pass.