### PR TITLE
feat: add `core` command for core memories endpoint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import { cmdMigrate } from './commands/migrate.js';
 import { cmdBrowse } from './commands/browse.js';
 import { cmdCompletions } from './commands/completions.js';
 import { cmdHistory } from './commands/history.js';
+import { cmdCore } from './commands/core.js';
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
@@ -182,6 +183,9 @@ try {
       break;
     case 'init':
       await cmdInit(args);
+      break;
+    case 'core':
+      await cmdCore(args);
       break;
     case 'history':
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw history <id>');

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,6 +1,6 @@
 export async function cmdCompletions(shell: string) {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
-    'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
+    'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'help'];
 
   const globalFlags = ['--help', '--version', '--json', '--quiet', '--namespace', '--limit', '--offset',

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -1,0 +1,56 @@
+/**
+ * Core memories command — list core memories (FREE endpoint)
+ */
+
+import type { ParsedArgs } from '../args.js';
+import { request } from '../http.js';
+import { c } from '../colors.js';
+import { outputJson, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
+
+export async function cmdCore(opts: ParsedArgs) {
+  const params = new URLSearchParams();
+  if (opts.limit != null && opts.limit !== true) params.set('limit', opts.limit);
+  if (opts.namespace) params.set('namespace', opts.namespace);
+
+  const result = await request('GET', `/v1/core?${params}`) as any;
+
+  if (outputJson) {
+    out(result);
+    return;
+  }
+
+  if (opts.raw) {
+    const memories = result.memories || result.core_memories || result.data || [];
+    for (const mem of memories) {
+      outputWrite(mem.content || '');
+    }
+    return;
+  }
+
+  const memories = result.memories || result.core_memories || result.data || [];
+
+  if (memories.length === 0) {
+    console.log(`${c.dim}No core memories found.${c.reset}`);
+    return;
+  }
+
+  const truncateWidth = noTruncate ? Infinity : (outputTruncate || 60);
+  const rows = memories.map((m: any) => ({
+    id: m.id?.slice(0, 8) || '?',
+    content: m.content?.length > truncateWidth ? m.content.slice(0, truncateWidth - 1) + '…' : (m.content || ''),
+    importance: m.importance != null ? m.importance.toFixed(2) : '-',
+    tags: m.metadata?.tags?.join(', ') || '',
+    created: m.created_at ? new Date(m.created_at).toLocaleDateString() : '',
+  }));
+
+  table(rows, [
+    { key: 'id', label: 'ID', width: 10 },
+    { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 62) },
+    { key: 'importance', label: 'IMP', width: 5 },
+    { key: 'tags', label: 'TAGS', width: 20 },
+    { key: 'created', label: 'CREATED', width: 12 },
+  ]);
+
+  const total = result.total ?? memories.length;
+  console.log(`${c.dim}─ ${memories.length} of ${total} core memories${c.reset}`);
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -304,6 +304,23 @@ Generate shell completion scripts.
   ${c.dim}eval "$(memoclaw completions zsh)"${c.reset}
   ${c.dim}memoclaw completions fish > ~/.config/fish/completions/memoclaw.fish${c.reset}`,
 
+      core: `${c.bold}memoclaw core${c.reset} [options]
+
+List core memories (FREE — no embeddings cost).
+
+Core memories are high-importance, foundational memories that define
+key facts, preferences, or identity. This endpoint is free to call.
+
+  ${c.dim}memoclaw core${c.reset}
+  ${c.dim}memoclaw core --namespace project1${c.reset}
+  ${c.dim}memoclaw core --limit 5 --json${c.reset}
+  ${c.dim}memoclaw core --raw | head -5${c.reset}
+
+Options:
+  --limit <n>            Max results
+  --namespace <name>     Filter by namespace
+  --raw                  Output content only (for piping)`,
+
       history: `${c.bold}memoclaw history${c.reset} <id>
 
 View the change history for a memory (FREE).
@@ -352,6 +369,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}context${c.reset} "query"        Get GPT-powered contextual summary ($0.01/call)
   ${c.cyan}consolidate${c.reset}            Merge similar memories
   ${c.cyan}relations${c.reset} <sub>        Manage memory relations
+  ${c.cyan}core${c.reset}                   List core memories (free)
   ${c.cyan}suggested${c.reset}              Get suggested memories for review
   ${c.cyan}status${c.reset}                 Check account & free tier info
   ${c.cyan}stats${c.reset}                  Memory statistics

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -104,6 +104,7 @@ const { cmdGet, cmdDelete, cmdUpdate } = await import('../src/commands/memory.js
 const { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } = await import('../src/commands/search.js');
 const { cmdCount, cmdSuggested, cmdGraph } = await import('../src/commands/status.js');
 const { cmdHistory } = await import('../src/commands/history.js');
+const { cmdCore } = await import('../src/commands/core.js');
 const { cmdRelations } = await import('../src/commands/relations.js');
 const { cmdNamespace } = await import('../src/commands/namespace.js');
 const { cmdExport, cmdPurge } = await import('../src/commands/data.js');
@@ -1280,6 +1281,65 @@ describe('list tags filter', () => {
 
     const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
     expect(url).toContain('tags=urgent%2Cfix');
+  });
+});
+
+describe('cmdCore', () => {
+  test('displays core memories in table', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'core-1111-2222-3333', content: 'User prefers dark mode', importance: 0.95, metadata: { tags: ['preference'] }, created_at: '2026-01-15T00:00:00Z' },
+        { id: 'core-4444-5555-6666', content: 'Primary language is TypeScript', importance: 0.9, metadata: { tags: ['tech'] }, created_at: '2026-01-20T00:00:00Z' },
+      ],
+      total: 2,
+    };
+    captureConsole();
+    await cmdCore({ _: [] } as any);
+    restoreConsole();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('User prefers dark mode');
+    expect(output).toContain('Primary language is TypeScript');
+    expect(output).toContain('2 of 2 core memories');
+  });
+
+  test('shows empty message when no core memories', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    captureConsole();
+    await cmdCore({ _: [] } as any);
+    restoreConsole();
+    expect(consoleOutput.join('\n')).toContain('No core memories found');
+  });
+
+  test('passes namespace and limit to query params', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdCore({ _: [], namespace: 'proj', limit: '5' } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/core'))?.url || '';
+    expect(url).toContain('namespace=proj');
+    expect(url).toContain('limit=5');
+  });
+
+  test('outputs JSON when --json flag set', async () => {
+    mockFetchResponse = { memories: [{ id: 'abc', content: 'test' }], total: 1 };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ json: true });
+    captureConsole();
+    await cmdCore({ _: [], json: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput[0]);
+    expect(parsed.memories).toBeDefined();
+  });
+
+  test('raw mode outputs content only', async () => {
+    mockFetchResponse = { memories: [{ id: 'a', content: 'raw content here' }], total: 1 };
+    captureConsole();
+    await cmdCore({ _: [], raw: true } as any);
+    restoreConsole();
+    expect(consoleOutput.join('\n')).toContain('raw content here');
   });
 });
 


### PR DESCRIPTION
## Summary

Add `memoclaw core` command to access the free `/v1/core` endpoint for core memories.

### Changes
- **src/commands/core.ts** — New `cmdCore` handler: table display, JSON, raw output modes
- **src/cli.ts** — Wire `core` case into command router
- **src/help.ts** — Add detailed help + command listing entry
- **src/commands/completions.ts** — Register in shell completions
- **test/commands.test.ts** — 5 tests: table display, empty state, query params, JSON mode, raw mode

### Flags supported
`--namespace`, `--limit`, `--json`, `--raw`, `--truncate`, `--no-truncate`

### Notes
- This is a **free endpoint** — no embeddings cost
- Follows existing patterns from `list` and `suggested` commands
- All 354 tests pass

Fixes #51