### PR TITLE
feat: batch CLI enhancements (bulk-delete tests, --file, --pinned/--immutable filters, --id-only, search formats)

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -11,7 +11,7 @@ export interface ParsedArgs {
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
   'force', 'count', 'wide', 'pretty', 'watch', 'interactive', 'yes', 'reverse',
-  'noTruncate', 'batch',
+  'noTruncate', 'batch', 'idOnly',
 ]);
 
 /** Short flag aliases */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { setRequestTimeout } from './http.js';
 import { printHelp } from './help.js';
 
 // Commands
-import { cmdStore, cmdStoreBatch } from './commands/store.js';
+import { cmdStore, cmdStoreBatch, readFileContent } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
 import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } from './commands/memory.js';
@@ -76,11 +76,14 @@ try {
         break;
       }
       let content = rest[0] || (args.content && args.content !== true ? args.content : undefined);
+      if (!content && args.file) {
+        content = readFileContent(args.file);
+      }
       if (!content) {
         const stdin = await readStdin();
         if (stdin) content = stdin;
       }
-      if (!content) throw new Error('Content required. Provide as argument, --content flag, or pipe via stdin.');
+      if (!content) throw new Error('Content required. Provide as argument, --content flag, --file flag, or pipe via stdin.');
       await cmdStore(content, args);
       break;
     }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -12,6 +12,8 @@ export async function cmdList(opts: ParsedArgs) {
   if (opts.memoryType) params.set('memory_type', opts.memoryType);
   if (opts.agentId) params.set('agent_id', opts.agentId);
   if (opts.sessionId) params.set('session_id', opts.sessionId);
+  if (opts.pinned) params.set('pinned', 'true');
+  if (opts.immutable) params.set('immutable', 'true');
 
   // Watch mode
   if (opts.watch) {
@@ -131,6 +133,8 @@ export async function cmdList(opts: ParsedArgs) {
           updated: { key: 'updated', label: 'UPDATED', width: 12 },
           namespace: { key: 'namespace', label: 'NAMESPACE', width: 15 },
           type: { key: 'memory_type', label: 'TYPE', width: 10 },
+          pinned: { key: 'pinned', label: 'PINNED', width: 8 },
+          immutable: { key: 'immutable', label: 'IMMUTABLE', width: 10 },
         };
         columns = selected.map((k: string) => colMap[k] || { key: k, label: k.toUpperCase(), width: 20 });
       }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, noTruncate, out, success, info, truncate, readStdin } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, success, info, truncate, table, readStdin } from '../output.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -22,6 +22,14 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     for (const mem of memories) {
       console.log(mem.content);
     }
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const memories = result.memories || result.data || [];
+    const rows = memories.map((m: any) => ({
+      id: m.id?.slice(0, 8) || '?',
+      content: m.content || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+    }));
+    out(rows);
   } else {
     const memories = result.memories || result.data || [];
     if (memories.length === 0) {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
@@ -80,11 +81,19 @@ export async function cmdStore(content: string, opts: ParsedArgs) {
   if (opts.agentId) body.agent_id = opts.agentId;
   if (opts.expiresAt) body.expires_at = opts.expiresAt;
 
-  const result = await request('POST', '/v1/store', body);
-  if (outputJson) {
+  const result = await request('POST', '/v1/store', body) as any;
+  if (opts.idOnly) {
+    console.log(result.id || '');
+  } else if (outputJson) {
     out(result);
   } else {
     success(`Memory stored${result.id ? ` (${c.cyan}${result.id}${c.reset})` : ''}`);
     if (result.importance !== undefined) info(`Importance: ${result.importance}`);
   }
+}
+
+/** Read content from --file flag */
+export function readFileContent(filePath: string): string {
+  if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+  return fs.readFileSync(filePath, 'utf-8').trim();
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -33,7 +33,9 @@ Options:
   --pinned               Pin the memory
   --session-id <id>      Session identifier for tracking
   --agent-id <id>        Agent identifier for multi-agent setups
-  --expires-at <date>    Expiration date (ISO 8601)`,
+  --expires-at <date>    Expiration date (ISO 8601)
+  --file <path>          Read content from a file
+  --id-only              Print only the memory ID (for scripting)`,
 
       search: `${c.bold}memoclaw search${c.reset} "query" [options]
 
@@ -44,6 +46,7 @@ Options:
   --limit <n>            Max results (default: 10)
   --namespace <name>     Filter by namespace
   --tags <tag1,tag2>     Filter by tags
+  --format <fmt>         Output format: json, csv, tsv, yaml
   --raw                  Output content only (for piping)`,
 
       context: `${c.bold}memoclaw context${c.reset} "query" [options]
@@ -85,6 +88,8 @@ Options:
   --session-id <id>      Filter by session ID
   --columns <cols>       Select columns (id,content,importance,tags,created)
   --wide                 Use wider columns in table output
+  --pinned               Filter pinned memories only
+  --immutable            Filter immutable memories only
   --raw                  Output content only (for piping)
   --watch                Watch for changes (continuous polling)
   --watch-interval <ms>  Polling interval (default: 5000)`,

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -100,7 +100,7 @@ function resetOutputState(overrides: Record<string, any> = {}) {
 const { cmdStore, cmdStoreBatch } = await import('../src/commands/store.js');
 const { cmdRecall } = await import('../src/commands/recall.js');
 const { cmdList } = await import('../src/commands/list.js');
-const { cmdGet, cmdDelete, cmdUpdate } = await import('../src/commands/memory.js');
+const { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } = await import('../src/commands/memory.js');
 const { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } = await import('../src/commands/search.js');
 const { cmdCount, cmdSuggested, cmdGraph } = await import('../src/commands/status.js');
 const { cmdHistory } = await import('../src/commands/history.js');
@@ -1284,6 +1284,7 @@ describe('list tags filter', () => {
   });
 });
 
+
 describe('cmdCore', () => {
   test('displays core memories in table', async () => {
     mockFetchResponse = {
@@ -1340,6 +1341,146 @@ describe('cmdCore', () => {
     await cmdCore({ _: [], raw: true } as any);
     restoreConsole();
     expect(consoleOutput.join('\n')).toContain('raw content here');
+  });
+});
+
+// ─── #43: bulk-delete tests ──────────────────────────────────────────────────
+
+describe('cmdBulkDelete', () => {
+  test('sends POST /v1/memories/bulk-delete with IDs', async () => {
+    mockFetchResponse = { deleted: 3 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdBulkDelete(['id1', 'id2', 'id3'], { _: [] } as any);
+    restoreConsole();
+    const call = allFetches.find(f => f.url.includes('/bulk-delete'));
+    expect(call).toBeDefined();
+    const body = JSON.parse(call!.options.body);
+    expect(body.ids).toEqual(['id1', 'id2', 'id3']);
+  });
+
+  test('shows success message with count', async () => {
+    mockFetchResponse = { deleted: 2 };
+    captureConsole();
+    await cmdBulkDelete(['a', 'b'], { _: [] } as any);
+    restoreConsole();
+    expect(consoleOutput.join('\n')).toContain('2');
+  });
+
+  test('JSON mode outputs raw response', async () => {
+    mockFetchResponse = { deleted: 1, ids: ['abc'] };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ json: true });
+    captureConsole();
+    await cmdBulkDelete(['abc'], { _: [], json: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput[0]);
+    expect(parsed.deleted).toBe(1);
+  });
+
+  test('uses ids.length as fallback when deleted not in response', async () => {
+    mockFetchResponse = {};
+    captureConsole();
+    await cmdBulkDelete(['x', 'y'], { _: [] } as any);
+    restoreConsole();
+    expect(consoleOutput.join('\n')).toContain('2');
+  });
+});
+
+// ─── #59: store --id-only ────────────────────────────────────────────────────
+
+describe('store --id-only', () => {
+  test('prints only the memory ID', async () => {
+    mockFetchResponse = { id: 'mem-12345678-abcd', importance: 0.5 };
+    captureConsole();
+    await cmdStore('test content', { _: [], idOnly: true } as any);
+    restoreConsole();
+    expect(consoleOutput).toEqual(['mem-12345678-abcd']);
+  });
+
+  test('prints empty string when no ID returned', async () => {
+    mockFetchResponse = { importance: 0.5 };
+    captureConsole();
+    await cmdStore('test', { _: [], idOnly: true } as any);
+    restoreConsole();
+    expect(consoleOutput).toEqual(['']);
+  });
+});
+
+// ─── #58: list --pinned/--immutable filters ──────────────────────────────────
+
+describe('list pinned/immutable filters', () => {
+  test('passes pinned=true to query params', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], pinned: true } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('pinned=true');
+  });
+
+  test('passes immutable=true to query params', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], immutable: true } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('immutable=true');
+  });
+
+  test('both filters together', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], pinned: true, immutable: true } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('pinned=true');
+    expect(url).toContain('immutable=true');
+  });
+});
+
+// ─── #60: search format support ──────────────────────────────────────────────
+
+describe('search csv/yaml format', () => {
+  test('csv format outputs comma-separated values', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'search-1111-2222', content: 'hello world', metadata: { tags: ['tag1'] } },
+      ],
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdSearch('hello', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id');
+    expect(output).toContain('content');
+    expect(output).toContain('hello world');
+  });
+
+  test('yaml format outputs yaml', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'yaml-1111-2222', content: 'yaml test', metadata: {} },
+      ],
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'yaml' });
+    captureConsole();
+    await cmdSearch('yaml', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('content: yaml test');
   });
 });
 


### PR DESCRIPTION
## Summary

Batch of 5 CLI improvements and test coverage additions.

### Changes

#### #43 — Bulk-delete test coverage
- 4 new tests for `cmdBulkDelete`: POST body, success message, JSON mode, fallback count

#### #44 — `--file` flag for store
- `memoclaw store --file notes.txt` reads content from a file
- Falls between `--content` and stdin in priority chain

#### #58 — `--pinned` and `--immutable` filters for list
- `memoclaw list --pinned` / `memoclaw list --immutable`
- Sends `pinned=true` / `immutable=true` query params
- Added as selectable columns via `--columns pinned,immutable`

#### #59 — `--id-only` flag for store
- `ID=$(memoclaw store "hello" --id-only)` — prints just the memory ID
- No jq dependency needed for scripting

#### #60 — csv/tsv/yaml format support for search
- `memoclaw search "query" --format csv` now works
- Parity with list/export/recall commands

### Tests
- 11 new tests added, all 360 tests pass

Fixes #43, Fixes #44, Fixes #58, Fixes #59, Fixes #60