### PR TITLE
fix: 6 bugs — x402 retry timeout, watch fingerprint, list options, timeout validation, column widths, configureOutput state leak

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,8 +63,16 @@ if (args.help) {
 if (!args.namespace && DEFAULT_NAMESPACE) args.namespace = DEFAULT_NAMESPACE;
 
 // Configure request timeout
-const TIMEOUT_MS = args.timeout ? parseInt(args.timeout) * 1000 : DEFAULT_TIMEOUT * 1000;
-setRequestTimeout(TIMEOUT_MS);
+if (args.timeout) {
+  const parsed = parseInt(args.timeout);
+  if (isNaN(parsed) || parsed < 0) {
+    console.error(`${c.red}Error:${c.reset} Invalid timeout value "${args.timeout}". Must be a positive number (seconds).`);
+    process.exit(1);
+  }
+  setRequestTimeout(parsed * 1000);
+} else {
+  setRequestTimeout(DEFAULT_TIMEOUT * 1000);
+}
 
 try {
   switch (cmd) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,6 +3,109 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
 
+/** Apply client-side sorting to memories array */
+function sortMemories(memories: any[], opts: ParsedArgs): any[] {
+  if (!opts.sortBy || memories.length === 0) return memories;
+
+  const sortKey = opts.sortBy;
+  const sortKeyMap: Record<string, string> = {
+    created: 'created_at',
+    updated: 'updated_at',
+  };
+  const resolvedKey = sortKeyMap[sortKey] || sortKey;
+  const reverse = !!opts.reverse;
+
+  return [...memories].sort((a: any, b: any) => {
+    let aVal = a[resolvedKey];
+    let bVal = b[resolvedKey];
+    if (aVal === undefined && resolvedKey.includes('.')) {
+      const parts = resolvedKey.split('.');
+      let obj: any = a;
+      for (const p of parts) obj = obj?.[p];
+      aVal = obj;
+      obj = b;
+      for (const p of parts) obj = obj?.[p];
+      bVal = obj;
+    }
+    if (aVal?.includes?.('-') && !isNaN(Date.parse(aVal))) {
+      aVal = new Date(aVal).getTime();
+      bVal = new Date(bVal as string).getTime();
+    }
+    if (resolvedKey === 'importance') {
+      aVal = parseFloat(aVal) || 0;
+      bVal = parseFloat(bVal) || 0;
+    }
+    if (aVal < bVal) return reverse ? 1 : -1;
+    if (aVal > bVal) return reverse ? -1 : 1;
+    return 0;
+  });
+}
+
+/** Build column definitions based on opts */
+function buildColumns(opts: ParsedArgs): { key: string; label: string; width?: number }[] {
+  const idWidth = opts.wide ? 36 : 10;
+
+  if (opts.columns) {
+    const selected = opts.columns.split(',').map((c: string) => c.trim());
+    const colMap: Record<string, { key: string; label: string; width?: number }> = {
+      id: { key: 'id', label: 'ID', width: idWidth },
+      content: { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 52) },
+      importance: { key: 'importance', label: 'IMP', width: 5 },
+      tags: { key: 'tags', label: 'TAGS', width: 20 },
+      created: { key: 'created', label: 'CREATED', width: 12 },
+      updated: { key: 'updated', label: 'UPDATED', width: 12 },
+      namespace: { key: 'namespace', label: 'NAMESPACE', width: 15 },
+      type: { key: 'memory_type', label: 'TYPE', width: 10 },
+      pinned: { key: 'pinned', label: 'PINNED', width: 8 },
+      immutable: { key: 'immutable', label: 'IMMUTABLE', width: 10 },
+    };
+    return selected.map((k: string) => colMap[k] || { key: k, label: k.toUpperCase(), width: 20 });
+  }
+
+  return [
+    { key: 'id', label: 'ID', width: idWidth },
+    { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 52) },
+    { key: 'importance', label: 'IMP', width: 5 },
+    { key: 'tags', label: 'TAGS', width: 20 },
+    { key: 'created', label: 'CREATED', width: 12 },
+  ];
+}
+
+/** Render memories as a table with the given columns */
+function renderTable(memories: any[], columns: { key: string; label: string; width?: number }[], opts: ParsedArgs, total?: number) {
+  if (memories.length === 0) {
+    console.log(`${c.dim}No memories found.${c.reset}`);
+    return;
+  }
+
+  const rows = memories.map((m: any) => {
+    const row: Record<string, any> = {};
+    for (const col of columns) {
+      let val = m[col.key];
+      if (col.key === 'content' && val?.length > (col.width || 50)) {
+        val = val.slice(0, (col.width || 50) - 1) + '…';
+      } else if (col.key === 'importance' && val !== undefined) {
+        val = val.toFixed(2);
+      } else if (col.key === 'tags') {
+        val = m.metadata?.tags?.join(', ') || '';
+      } else if ((col.key === 'created' || col.key === 'updated') && m[`${col.key}_at`]) {
+        val = new Date(m[`${col.key}_at`]).toLocaleDateString();
+      } else if (val === undefined || val === null) {
+        val = '';
+      } else {
+        val = String(val);
+      }
+      row[col.key] = val;
+    }
+    return row;
+  });
+
+  table(rows, columns, { wide: !!opts.wide });
+  if (total !== undefined) {
+    console.log(`${c.dim}─ ${memories.length} of ${total} memories${c.reset}`);
+  }
+}
+
 export async function cmdList(opts: ParsedArgs) {
   const params = new URLSearchParams();
   if (opts.limit != null && opts.limit !== true) params.set('limit', opts.limit);
@@ -17,41 +120,24 @@ export async function cmdList(opts: ParsedArgs) {
 
   // Watch mode
   if (opts.watch) {
-    let lastTotal = -1;
+    let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
+    const columns = buildColumns(opts);
 
     console.log(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
     while (true) {
       try {
         const result = await request('GET', `/v1/memories?${params}`) as any;
-        const memories = result.memories || result.data || [];
+        let memories = result.memories || result.data || [];
         const total = result.total ?? memories.length;
+        const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
-        if (total !== lastTotal) {
-          if (lastTotal >= 0) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
-          lastTotal = total;
-
-          if (memories.length === 0) {
-            console.log(`${c.dim}No memories found.${c.reset}`);
-          } else {
-            const truncateWidth = noTruncate ? Infinity : (outputTruncate || 50);
-            const rows = memories.map((m: any) => ({
-              id: m.id?.slice(0, 8) || '?',
-              content: m.content?.length > truncateWidth ? m.content.slice(0, truncateWidth) + '…' : (m.content || ''),
-              importance: m.importance?.toFixed(2) || '-',
-              tags: m.metadata?.tags?.join(', ') || '',
-              created: m.created_at ? new Date(m.created_at).toLocaleDateString() : '',
-            }));
-            table(rows, [
-              { key: 'id', label: 'ID', width: 10 },
-              { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 52) },
-              { key: 'importance', label: 'IMP', width: 5 },
-              { key: 'tags', label: 'TAGS', width: 20 },
-              { key: 'created', label: 'CREATED', width: 12 },
-            ]);
-            console.log(`${c.dim}─ ${memories.length} of ${total} memories${c.reset}`);
-          }
+        if (fingerprint !== lastFingerprint) {
+          if (lastFingerprint) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+          lastFingerprint = fingerprint;
+          memories = sortMemories(memories, opts);
+          renderTable(memories, columns, opts, total);
         }
 
         await new Promise(r => setTimeout(r, pollInterval));
@@ -73,97 +159,8 @@ export async function cmdList(opts: ParsedArgs) {
     }
   } else {
     let memories = result.memories || result.data || [];
-
-    // Client-side sorting
-    if (opts.sortBy && memories.length > 0) {
-      const sortKey = opts.sortBy;
-      // Map user-friendly sort keys to actual API field names
-      const sortKeyMap: Record<string, string> = {
-        created: 'created_at',
-        updated: 'updated_at',
-      };
-      const resolvedKey = sortKeyMap[sortKey] || sortKey;
-      const reverse = !!opts.reverse;
-      memories = [...memories].sort((a: any, b: any) => {
-        let aVal = a[resolvedKey];
-        let bVal = b[resolvedKey];
-        if (aVal === undefined && resolvedKey.includes('.')) {
-          const parts = resolvedKey.split('.');
-          let obj: any = a;
-          for (const p of parts) obj = obj?.[p];
-          aVal = obj;
-          obj = b;
-          for (const p of parts) obj = obj?.[p];
-          bVal = obj;
-        }
-        if (aVal?.includes?.('-') && !isNaN(Date.parse(aVal))) {
-          aVal = new Date(aVal).getTime();
-          bVal = new Date(bVal as string).getTime();
-        }
-        if (resolvedKey === 'importance') {
-          aVal = parseFloat(aVal) || 0;
-          bVal = parseFloat(bVal) || 0;
-        }
-        if (aVal < bVal) return reverse ? 1 : -1;
-        if (aVal > bVal) return reverse ? -1 : 1;
-        return 0;
-      });
-    }
-
-    if (memories.length === 0) {
-      console.log(`${c.dim}No memories found.${c.reset}`);
-    } else {
-      const idWidth = opts.wide ? 36 : 10;
-      let columns = [
-        { key: 'id', label: 'ID', width: idWidth },
-        { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 52) },
-        { key: 'importance', label: 'IMP', width: 5 },
-        { key: 'tags', label: 'TAGS', width: 20 },
-        { key: 'created', label: 'CREATED', width: 12 },
-      ];
-
-      if (opts.columns) {
-        const selected = opts.columns.split(',').map((c: string) => c.trim());
-        const colMap: Record<string, { key: string; label: string; width?: number }> = {
-          id: { key: 'id', label: 'ID', width: 10 },
-          content: { key: 'content', label: 'CONTENT', width: noTruncate ? 200 : (outputTruncate || 52) },
-          importance: { key: 'importance', label: 'IMP', width: 5 },
-          tags: { key: 'tags', label: 'TAGS', width: 20 },
-          created: { key: 'created', label: 'CREATED', width: 12 },
-          updated: { key: 'updated', label: 'UPDATED', width: 12 },
-          namespace: { key: 'namespace', label: 'NAMESPACE', width: 15 },
-          type: { key: 'memory_type', label: 'TYPE', width: 10 },
-          pinned: { key: 'pinned', label: 'PINNED', width: 8 },
-          immutable: { key: 'immutable', label: 'IMMUTABLE', width: 10 },
-        };
-        columns = selected.map((k: string) => colMap[k] || { key: k, label: k.toUpperCase(), width: 20 });
-      }
-
-      const rows = memories.map((m: any) => {
-        const row: Record<string, any> = {};
-        for (const col of columns) {
-          let val = m[col.key];
-          if (col.key === 'content' && val?.length > (col.width || 50)) {
-            val = val.slice(0, (col.width || 50) - 1) + '…';
-          } else if (col.key === 'importance' && val !== undefined) {
-            val = val.toFixed(2);
-          } else if (col.key === 'tags') {
-            val = m.metadata?.tags?.join(', ') || '';
-          } else if ((col.key === 'created' || col.key === 'updated') && m[`${col.key}_at`]) {
-            val = new Date(m[`${col.key}_at`]).toLocaleDateString();
-          } else if (val === undefined || val === null) {
-            val = '';
-          } else {
-            val = String(val);
-          }
-          row[col.key] = val;
-        }
-        return row;
-      });
-      table(rows, columns, { wide: !!opts.wide });
-      if (result.total !== undefined) {
-        console.log(`${c.dim}─ ${memories.length} of ${result.total} memories${c.reset}`);
-      }
-    }
+    memories = sortMemories(memories, opts);
+    const columns = buildColumns(opts);
+    renderTable(memories, columns, opts, result.total);
   }
 }

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -33,7 +33,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
 
   // Watch mode
   if (opts.watch) {
-    let lastCount = -1;
+    let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
 
     console.log(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
@@ -42,10 +42,11 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
       try {
         const result = await request('POST', '/v1/recall', body) as any;
         const memories = result.memories || [];
+        const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
-        if (memories.length !== lastCount) {
-          if (lastCount >= 0) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
-          lastCount = memories.length;
+        if (fingerprint !== lastFingerprint) {
+          if (lastFingerprint) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+          lastFingerprint = fingerprint;
           renderMemories(memories);
         }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -73,11 +73,23 @@ export async function request(method: string, path: string, body: any = null) {
       const paymentHeaders = client.encodePaymentSignatureHeader(paymentPayload);
       if (process.env.DEBUG) console.error('Payment headers:', paymentHeaders);
 
-      res = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json', ...paymentHeaders },
-        body: body ? JSON.stringify(body) : undefined,
-      });
+      const retryController = new AbortController();
+      const retryTimeoutId = setTimeout(() => retryController.abort(), _timeoutMs);
+      try {
+        res = await fetch(url, {
+          method,
+          headers: { 'Content-Type': 'application/json', ...paymentHeaders },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: retryController.signal,
+        });
+      } catch (retryErr: any) {
+        clearTimeout(retryTimeoutId);
+        if (retryErr.name === 'AbortError') {
+          throw new Error(`x402 payment retry timed out after ${_timeoutMs / 1000}s`);
+        }
+        throw retryErr;
+      }
+      clearTimeout(retryTimeoutId);
 
       if (process.env.DEBUG) {
         console.error('=== Retry Response ===');

--- a/src/output.ts
+++ b/src/output.ts
@@ -25,9 +25,12 @@ export function configureOutput(args: any) {
   outputQuiet = !!args.quiet;
   outputPretty = !!args.pretty;
 
+  // Always reset field and file — use explicit null/undefined to clear
   if (args.field && args.field !== true) {
     outputField = String(args.field);
     outputJson = true;
+  } else {
+    outputField = null;
   }
 
   if (args.format) {
@@ -36,6 +39,8 @@ export function configureOutput(args: any) {
     if (fmt === 'json' || fmt === 'table' || fmt === 'csv' || fmt === 'tsv' || fmt === 'yaml') {
       outputFormat = fmt as typeof outputFormat;
     }
+  } else {
+    outputFormat = args.json ? 'json' : 'table';
   }
   if (args.json) outputFormat = 'json';
 
@@ -43,6 +48,8 @@ export function configureOutput(args: any) {
     outputTruncate = parseInt(args.truncate);
   } else if (args.truncate === true) {
     outputTruncate = 80;
+  } else {
+    outputTruncate = 0;
   }
 
   noTruncate = !!args.noTruncate;
@@ -51,6 +58,8 @@ export function configureOutput(args: any) {
   if (args.output) {
     outputFile = String(args.output);
     fs.writeFileSync(outputFile, '');
+  } else {
+    outputFile = null;
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1054,6 +1054,18 @@ describe('timeout config', () => {
     // '0' is truthy as string, so parseInt('0') * 1000 = 0
     expect(timeoutMs).toBe(0);
   });
+
+  test('invalid timeout value is detected as NaN', () => {
+    const args = parseArgs(['list', '--timeout', 'abc']);
+    const parsed = parseInt(args.timeout);
+    expect(isNaN(parsed)).toBe(true);
+  });
+
+  test('negative timeout value is detected', () => {
+    const args = parseArgs(['list', '--timeout', '-5']);
+    const parsed = parseInt(args.timeout);
+    expect(parsed < 0).toBe(true);
+  });
 });
 
 // ─── Combined flags with output options ─────────────────────────────────────
@@ -1181,6 +1193,34 @@ describe('store --content flag', () => {
     const [cmd, ...rest] = result._;
     const content = rest[0] || (result.content && result.content !== true ? result.content : undefined);
     expect(content).toBe('flag content');
+  });
+});
+
+// ─── Watch mode fingerprint ──────────────────────────────────────────────────
+
+describe('watch mode fingerprint', () => {
+  test('detects changes when IDs differ even if count is same', () => {
+    const memories1 = [{ id: 'aaa', updated_at: '2024-01-01' }, { id: 'bbb', updated_at: '2024-01-01' }];
+    const memories2 = [{ id: 'aaa', updated_at: '2024-01-01' }, { id: 'ccc', updated_at: '2024-01-02' }];
+    const fp1 = memories1.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    const fp2 = memories2.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    expect(fp1).not.toBe(fp2);
+    expect(memories1.length).toBe(memories2.length); // count is same
+  });
+
+  test('detects changes when updated_at differs', () => {
+    const memories1 = [{ id: 'aaa', updated_at: '2024-01-01' }];
+    const memories2 = [{ id: 'aaa', updated_at: '2024-01-02' }];
+    const fp1 = memories1.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    const fp2 = memories2.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    expect(fp1).not.toBe(fp2);
+  });
+
+  test('same memories produce same fingerprint', () => {
+    const memories = [{ id: 'aaa', updated_at: '2024-01-01' }, { id: 'bbb', updated_at: '2024-01-02' }];
+    const fp1 = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    const fp2 = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
+    expect(fp1).toBe(fp2);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes 6 bugs found during codebase audit. All 370 tests pass.

### Bugs Fixed

1. **x402 retry timeout (#63)** — The x402 payment retry `fetch()` had no `AbortController` timeout, so it could hang indefinitely. Now uses the same timeout as the initial request.

2. **Watch mode change detection (#64)** — `recall --watch` and `list --watch` detected changes by comparing result count only. If a memory was deleted and another added, the count stayed the same and the display never refreshed. Now uses an ID+updated_at fingerprint.

3. **list --watch ignores options (#65)** — Watch mode had its own hardcoded rendering path that ignored `--sort-by`, `--columns`, `--reverse`, and `--wide`. Refactored list.ts to extract `sortMemories()`, `buildColumns()`, and `renderTable()` shared helpers used by both code paths.

4. **Invalid --timeout causes instant timeout (#66)** — `--timeout abc` produced `NaN`, and `setTimeout(fn, NaN)` fires immediately in Node.js. Now validates input and exits with a clear error.

5. **--columns --wide ID width (#67)** — The `--columns` code path always set ID width to 10, ignoring `--wide`. Now uses `opts.wide ? 36 : 10` consistently.

6. **configureOutput() state leak** — `configureOutput()` didn't properly reset `outputField`, `outputFile`, `outputFormat`, or `outputTruncate` when called with null/undefined values. This caused cross-module state pollution on CI where `output.test.ts` set `outputField='content'` which then leaked into `commands.test.ts`, breaking all JSON mode tests.

### Tests

- 5 new tests added (watch fingerprint, timeout validation)
- All 370 tests pass locally and on CI
- Fixed 15 flaky CI test failures caused by state leak

Fixes #63, Fixes #64, Fixes #65, Fixes #66, Fixes #67