### PR TITLE
fix: add --format csv/yaml/tsv to list & core, fix orphaned test, sync completions test

### DIFF
--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
 
 export async function cmdCore(opts: ParsedArgs) {
   const params = new URLSearchParams();
@@ -31,6 +31,18 @@ export async function cmdCore(opts: ParsedArgs) {
 
   if (memories.length === 0) {
     console.log(`${c.dim}No core memories found.${c.reset}`);
+    return;
+  }
+
+  if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const rows = memories.map((m: any) => ({
+      id: m.id || '',
+      content: m.content || '',
+      importance: m.importance?.toFixed(2) || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+      created: m.created_at || '',
+    }));
+    out(rows);
     return;
   }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
 
 /** Apply client-side sorting to memories array */
 function sortMemories(memories: any[], opts: ParsedArgs): any[] {
@@ -157,6 +157,18 @@ export async function cmdList(opts: ParsedArgs) {
     for (const mem of memories) {
       outputWrite(mem.content || '');
     }
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    let memories = result.memories || result.data || [];
+    memories = sortMemories(memories, opts);
+    const rows = memories.map((m: any) => ({
+      id: m.id || '',
+      content: m.content || '',
+      importance: m.importance?.toFixed(2) || '',
+      namespace: m.namespace || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+      created: m.created_at || '',
+    }));
+    out(rows);
   } else {
     let memories = result.memories || result.data || [];
     memories = sortMemories(memories, opts);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -307,14 +307,16 @@ describe('export format', () => {
 // ─── Completions ─────────────────────────────────────────────────────────────
 
 describe('completions', () => {
-  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'ingest', 'extract',
-    'context', 'consolidate', 'relations', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
+    'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(28);
+    expect(commands.length).toBe(30);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
+    expect(commands).toContain('bulk-delete');
+    expect(commands).toContain('core');
     expect(commands).toContain('export');
     expect(commands).toContain('import');
     expect(commands).toContain('stats');

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -878,7 +878,6 @@ describe('cmdExtract', () => {
     await expect(cmdExtract('   \n\t  ', { _: [] } as any)).rejects.toThrow('empty');
     restoreConsole();
   });
-});
 
   test('accepts text longer than 8192 chars', async () => {
     mockFetchResponse = { memories: [] };
@@ -887,6 +886,7 @@ describe('cmdExtract', () => {
     expect(getLastBody().text).toBe(longText);
     restoreConsole();
   });
+});
 
 // ─── Ingest ──────────────────────────────────────────────────────────────────
 
@@ -1481,6 +1481,110 @@ describe('search csv/yaml format', () => {
     resetOutputState();
     const output = consoleOutput.join('\n');
     expect(output).toContain('content: yaml test');
+  });
+});
+
+// ─── #70: list format support ────────────────────────────────────────────────
+
+describe('list csv/yaml format', () => {
+  test('csv format outputs comma-separated values', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'list-1111-2222', content: 'hello world', importance: 0.7, namespace: 'test', metadata: { tags: ['tag1'] }, created_at: '2026-01-01T00:00:00Z' },
+      ],
+      total: 1,
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdList({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id');
+    expect(output).toContain('content');
+    expect(output).toContain('hello world');
+    expect(output).toContain('tag1');
+  });
+
+  test('yaml format outputs yaml', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'yaml-1111-2222', content: 'yaml test', importance: 0.5, metadata: {}, created_at: '2026-01-01T00:00:00Z' },
+      ],
+      total: 1,
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'yaml' });
+    captureConsole();
+    await cmdList({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('content: yaml test');
+  });
+
+  test('tsv format outputs tab-separated values', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'tsv-1111-2222', content: 'tsv test', importance: 0.5, metadata: { tags: ['a'] }, created_at: '2026-01-01T00:00:00Z' },
+      ],
+      total: 1,
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'tsv' });
+    captureConsole();
+    await cmdList({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id\t');
+    expect(output).toContain('tsv test');
+  });
+});
+
+// ─── #72: core format support ────────────────────────────────────────────────
+
+describe('core csv/yaml format', () => {
+  test('csv format outputs comma-separated values', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'core-1111-2222', content: 'core csv test', importance: 0.9, metadata: { tags: ['pref'] }, created_at: '2026-01-15T00:00:00Z' },
+      ],
+      total: 1,
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdCore({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id');
+    expect(output).toContain('content');
+    expect(output).toContain('core csv test');
+  });
+
+  test('yaml format outputs yaml', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'core-yaml-2222', content: 'core yaml test', importance: 0.8, metadata: {}, created_at: '2026-01-20T00:00:00Z' },
+      ],
+      total: 1,
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'yaml' });
+    captureConsole();
+    await cmdCore({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('content: core yaml test');
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #70, #71, #72

### Bug fixes
- **list command format support (#70):** `list` now supports `--format csv/yaml/tsv`. Previously these flags were silently ignored and table output was shown instead.
- **core command format support (#72):** `core` now supports `--format csv/yaml/tsv` for consistent format handling across commands.
- **Orphaned test (#71):** Moved the extract test `'accepts text longer than 8192 chars'` back inside its `cmdExtract` describe block.
- **Completions test sync (#71):** Added `bulk-delete` and `core` to the completions test array (28 → 30 commands).

### Tests
- 5 new tests for list/core CSV, YAML, and TSV format output
- All 375 tests pass, build succeeds