### PR TITLE
fix: outputWrite consistency + --format csv/yaml/tsv for suggested command

### DIFF
--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -1,27 +1,27 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, outputFormat, out, truncate } from '../output.js';
+import { outputJson, outputTruncate, outputFormat, out, outputWrite, truncate } from '../output.js';
 
 /** Render a list of recall memories to stdout (shared between normal and watch mode) */
 function renderMemories(memories: any[], opts: { showId?: boolean } = {}) {
   if (memories.length === 0) {
-    console.log(`${c.dim}No memories found.${c.reset}`);
+    outputWrite(`${c.dim}No memories found.${c.reset}`);
     return;
   }
   for (const mem of memories) {
     const sim = mem.similarity?.toFixed(3) || '???';
     const simColor = (mem.similarity || 0) > 0.8 ? c.green : (mem.similarity || 0) > 0.5 ? c.yellow : c.red;
     const content = outputTruncate ? truncate(mem.content, outputTruncate) : mem.content;
-    console.log(`${simColor}[${sim}]${c.reset} ${content}`);
+    outputWrite(`${simColor}[${sim}]${c.reset} ${content}`);
     if (mem.metadata?.tags?.length) {
-      console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+      outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
     }
     if (opts.showId && mem.id) {
-      console.log(`  ${c.dim}id: ${mem.id}${c.reset}`);
+      outputWrite(`  ${c.dim}id: ${mem.id}${c.reset}`);
     }
   }
-  console.log(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''}${c.reset}`);
+  outputWrite(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''}${c.reset}`);
 }
 
 export async function cmdRecall(query: string, opts: ParsedArgs) {
@@ -36,7 +36,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
     let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
 
-    console.log(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
+    outputWrite(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
     while (true) {
       try {
@@ -45,7 +45,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
         if (fingerprint !== lastFingerprint) {
-          if (lastFingerprint) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+          if (lastFingerprint) outputWrite(`${c.dim}${'─'.repeat(40)}${c.reset}`);
           lastFingerprint = fingerprint;
           renderMemories(memories);
         }
@@ -75,7 +75,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     const memories = result.memories || [];
     for (const mem of memories) {
-      console.log(mem.content);
+      outputWrite(mem.content);
     }
   } else {
     renderMemories(result.memories || [], { showId: true });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputFormat, outputTruncate, noTruncate, out, success, info, truncate, table, readStdin } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, truncate, table, readStdin } from '../output.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -20,12 +20,12 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     const memories = result.memories || result.data || [];
     for (const mem of memories) {
-      console.log(mem.content);
+      outputWrite(mem.content);
     }
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     const memories = result.memories || result.data || [];
     const rows = memories.map((m: any) => ({
-      id: m.id?.slice(0, 8) || '?',
+      id: m.id || '',
       content: m.content || '',
       tags: m.metadata?.tags?.join(', ') || '',
     }));
@@ -33,17 +33,17 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else {
     const memories = result.memories || result.data || [];
     if (memories.length === 0) {
-      console.log(`${c.dim}No memories found.${c.reset}`);
+      outputWrite(`${c.dim}No memories found.${c.reset}`);
     } else {
       const truncateWidth = outputTruncate || 80;
       for (const mem of memories) {
         const content = noTruncate ? mem.content : truncate(mem.content || '', truncateWidth);
-        console.log(`${c.cyan}${(mem.id || '?').slice(0, 8)}${c.reset}  ${content}`);
+        outputWrite(`${c.cyan}${(mem.id || '?').slice(0, 8)}${c.reset}  ${content}`);
         if (mem.metadata?.tags?.length) {
-          console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+          outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
         }
       }
-      console.log(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''} (text search, free)${c.reset}`);
+      outputWrite(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''} (text search, free)${c.reset}`);
     }
   }
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,7 +8,7 @@ import { c } from '../colors.js';
 import { API_URL } from '../config.js';
 import { getAccount, getWalletAuthHeader } from '../auth.js';
 import { getRequestTimeout } from '../http.js';
-import { outputJson, outputTruncate, noTruncate, out, success, info, table, truncate } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, table, truncate } from '../output.js';
 
 async function fetchWithTimeout(url: string, options: RequestInit = {}): Promise<Response> {
   const timeoutMs = getRequestTimeout();
@@ -127,26 +127,37 @@ export async function cmdSuggested(opts: ParsedArgs) {
 
   if (outputJson) {
     out(result);
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const suggestions = result.suggested || [];
+    const rows = suggestions.map((m: any) => ({
+      id: m.id || '',
+      category: m.category || '',
+      review_score: m.review_score?.toFixed(2) || '',
+      content: m.content || '',
+      importance: m.importance?.toFixed(2) || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+    }));
+    out(rows);
   } else {
     if (result.categories) {
       const cats = Object.entries(result.categories)
         .map(([k, v]) => `${c.bold}${k}${c.reset}=${v}`).join('  ');
-      console.log(`Categories: ${cats}`);
-      console.log(`${c.dim}${'─'.repeat(60)}${c.reset}`);
+      outputWrite(`Categories: ${cats}`);
+      outputWrite(`${c.dim}${'─'.repeat(60)}${c.reset}`);
     }
 
     const suggestions = result.suggested || [];
     if (suggestions.length === 0) {
-      console.log(`${c.dim}No suggested memories.${c.reset}`);
+      outputWrite(`${c.dim}No suggested memories.${c.reset}`);
     } else {
       for (const mem of suggestions) {
         const cat = mem.category?.toUpperCase() || '???';
         const catColor = { STALE: c.red, FRESH: c.green, HOT: c.yellow, DECAYING: c.magenta }[cat] || c.gray;
         const maxLen = noTruncate ? Infinity : (outputTruncate || 100);
         const text = truncate(mem.content || '', maxLen);
-        console.log(`${catColor}[${cat}]${c.reset} ${c.dim}(${mem.review_score?.toFixed(2) || '?'})${c.reset} ${text}`);
+        outputWrite(`${catColor}[${cat}]${c.reset} ${c.dim}(${mem.review_score?.toFixed(2) || '?'})${c.reset} ${text}`);
         if (mem.metadata?.tags?.length) {
-          console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+          outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
         }
       }
     }
@@ -171,11 +182,11 @@ export async function cmdGraph(id: string, opts: ParsedArgs) {
 
   const shortId = (s: string) => s?.slice(0, 8) || '?';
 
-  console.log();
-  console.log(`  ${c.bold}${c.cyan}[${shortId(mem.id)}]${c.reset} ${label(mem)}`);
+  outputWrite('');
+  outputWrite(`  ${c.bold}${c.cyan}[${shortId(mem.id)}]${c.reset} ${label(mem)}`);
 
   if (relations.length === 0) {
-    console.log(`  ${c.dim}  └── (no relations)${c.reset}`);
+    outputWrite(`  ${c.dim}  └── (no relations)${c.reset}`);
   } else {
     for (let i = 0; i < relations.length; i++) {
       const r = relations[i];
@@ -185,8 +196,8 @@ export async function cmdGraph(id: string, opts: ParsedArgs) {
         contradicts: c.red, supersedes: c.yellow, supports: c.green,
         derived_from: c.magenta, related_to: c.blue,
       }[r.relation_type] || c.dim;
-      console.log(`  ${c.dim}  ${branch}──${c.reset} ${typeColor}${r.relation_type}${c.reset} ${c.dim}→${c.reset} ${c.cyan}[${shortId(r.target_id)}]${c.reset}`);
+      outputWrite(`  ${c.dim}  ${branch}──${c.reset} ${typeColor}${r.relation_type}${c.reset} ${c.dim}→${c.reset} ${c.cyan}[${shortId(r.target_id)}]${c.reset}`);
     }
   }
-  console.log();
+  outputWrite('');
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1588,6 +1588,142 @@ describe('core csv/yaml format', () => {
   });
 });
 
+// ─── #74: recall outputWrite fix ─────────────────────────────────────────────
+
+describe('recall uses outputWrite', () => {
+  test('table output goes through outputWrite', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'rec-1111-2222', content: 'recall test', similarity: 0.85, metadata: { tags: ['t1'] } },
+      ],
+    };
+    resetOutputState();
+    captureConsole();
+    await cmdRecall('query', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('recall test');
+    expect(output).toContain('0.850');
+  });
+
+  test('raw output goes through outputWrite', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'raw-1111-2222', content: 'raw recall content', similarity: 0.9, metadata: {} },
+      ],
+    };
+    resetOutputState();
+    captureConsole();
+    await cmdRecall('query', { _: [], raw: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('raw recall content');
+  });
+});
+
+// ─── #74: search outputWrite fix ─────────────────────────────────────────────
+
+describe('search uses outputWrite', () => {
+  test('table output goes through outputWrite', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'srch-1111-2222', content: 'search test output', metadata: { tags: ['x'] } },
+      ],
+    };
+    resetOutputState();
+    captureConsole();
+    await cmdSearch('query', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('search test output');
+    expect(output).toContain('1 result');
+  });
+
+  test('raw output goes through outputWrite', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'srch-raw-2222', content: 'search raw content', metadata: {} },
+      ],
+    };
+    resetOutputState();
+    captureConsole();
+    await cmdSearch('q', { _: [], raw: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('search raw content');
+  });
+});
+
+// ─── #75: suggested csv/yaml format ──────────────────────────────────────────
+
+describe('suggested csv/yaml format', () => {
+  test('csv format outputs comma-separated values', async () => {
+    mockFetchResponse = {
+      suggested: [
+        { id: 'sug-1111-2222', category: 'stale', review_score: 0.75, content: 'suggested csv test', importance: 0.6, metadata: { tags: ['old'] } },
+      ],
+      categories: { stale: 1 },
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdSuggested({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id');
+    expect(output).toContain('category');
+    expect(output).toContain('suggested csv test');
+    expect(output).toContain('stale');
+  });
+
+  test('yaml format outputs yaml', async () => {
+    mockFetchResponse = {
+      suggested: [
+        { id: 'sug-yaml-2222', category: 'hot', review_score: 0.9, content: 'suggested yaml test', importance: 0.8, metadata: {} },
+      ],
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'yaml' });
+    captureConsole();
+    await cmdSuggested({ _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('content: suggested yaml test');
+    expect(output).toContain('category: hot');
+  });
+});
+
+// ─── #74: graph uses outputWrite ─────────────────────────────────────────────
+
+describe('graph uses outputWrite', () => {
+  test('ascii tree goes through outputWrite', async () => {
+    let callCount = 0;
+    mockFetchResponse = { memory: { id: 'graph-1111-2222-3333-4444', content: 'graph node' } };
+    // The graph command makes 2 requests: get memory + get relations
+    const origFetch = globalThis.fetch;
+    // We need to handle sequenced responses — the test mock handles one at a time
+    // First call returns memory, second returns relations
+    captureConsole();
+    resetOutputState();
+    // Just test that graph doesn't crash and produces output
+    // The mock will return the same response for both calls which is fine
+    mockFetchResponse = { memory: { id: 'graph-1111-2222-3333-4444', content: 'graph node test' }, relations: [] };
+    await cmdGraph('graph-1111-2222-3333-4444', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('graph-11');
+  });
+});
+
 describe('validateImportance', () => {
   test('accepts 0', () => expect(validateImportance('0')).toBe(0));
   test('accepts 1', () => expect(validateImportance('1')).toBe(1));


### PR DESCRIPTION
## Changes

### Bug fix (Fixes #74)
- **recall**: Replaced all `console.log` calls with `outputWrite` in `renderMemories()`, watch mode, and raw output — `--output <file>` now works
- **search**: Replaced `console.log` with `outputWrite` in table, raw, and summary output
- **suggested**: Replaced `console.log` with `outputWrite` in categories and suggestion rendering
- **graph**: Replaced `console.log` with `outputWrite` for ASCII tree output

### Enhancement (Fixes #75)
- **suggested --format csv/yaml/tsv**: Added structured output support with id, category, review_score, content, importance, tags columns

### Additional fix
- **search csv/tsv**: No longer truncates IDs to 8 chars in structured output formats (full IDs needed for scripting)

### Tests added (7 new)
- recall outputWrite: table + raw output verification
- search outputWrite: table + raw output verification
- suggested csv/yaml format: 2 tests
- graph outputWrite: ASCII tree verification

All 382 tests pass.