### PR TITLE
fix: use outputWrite across all commands, add --format csv/yaml/tsv to remaining commands

### DIFF
--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -30,7 +30,7 @@ export async function cmdCore(opts: ParsedArgs) {
   const memories = result.memories || result.core_memories || result.data || [];
 
   if (memories.length === 0) {
-    console.log(`${c.dim}No core memories found.${c.reset}`);
+    outputWrite(`${c.dim}No core memories found.${c.reset}`);
     return;
   }
 
@@ -64,5 +64,5 @@ export async function cmdCore(opts: ParsedArgs) {
   ]);
 
   const total = result.total ?? memories.length;
-  console.log(`${c.dim}─ ${memories.length} of ${total} core memories${c.reset}`);
+  outputWrite(`${c.dim}─ ${memories.length} of ${total} core memories${c.reset}`);
 }

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -166,7 +166,7 @@ export async function cmdPurge(opts: ParsedArgs) {
     ));
     rl.close();
     if (answer.trim().toLowerCase() !== 'yes') {
-      console.log(`${c.dim}Aborted.${c.reset}`);
+      outputWrite(`${c.dim}Aborted.${c.reset}`);
       return;
     }
   }

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -4,7 +4,7 @@
 
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, out, table } from '../output.js';
+import { outputJson, outputFormat, out, outputWrite, table } from '../output.js';
 
 export async function cmdHistory(id: string) {
   const result = await request('GET', `/v1/memories/${id}/history`) as any;
@@ -15,7 +15,17 @@ export async function cmdHistory(id: string) {
 
   const history = result.history || [];
   if (history.length === 0) {
-    console.log(`${c.dim}No history entries found.${c.reset}`);
+    outputWrite(`${c.dim}No history entries found.${c.reset}`);
+    return;
+  }
+
+  if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const rows = history.map((entry: any) => ({
+      id: entry.id || '',
+      date: entry.created_at || '',
+      fields: Object.keys(entry.changes || {}).join(', ') || '',
+    }));
+    out(rows);
     return;
   }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -74,7 +74,7 @@ function buildColumns(opts: ParsedArgs): { key: string; label: string; width?: n
 /** Render memories as a table with the given columns */
 function renderTable(memories: any[], columns: { key: string; label: string; width?: number }[], opts: ParsedArgs, total?: number) {
   if (memories.length === 0) {
-    console.log(`${c.dim}No memories found.${c.reset}`);
+    outputWrite(`${c.dim}No memories found.${c.reset}`);
     return;
   }
 
@@ -102,7 +102,7 @@ function renderTable(memories: any[], columns: { key: string; label: string; wid
 
   table(rows, columns, { wide: !!opts.wide });
   if (total !== undefined) {
-    console.log(`${c.dim}─ ${memories.length} of ${total} memories${c.reset}`);
+    outputWrite(`${c.dim}─ ${memories.length} of ${total} memories${c.reset}`);
   }
 }
 
@@ -124,7 +124,7 @@ export async function cmdList(opts: ParsedArgs) {
     const pollInterval = parseInt(opts.watchInterval || '5000');
     const columns = buildColumns(opts);
 
-    console.log(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
+    outputWrite(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
     while (true) {
       try {
@@ -134,7 +134,7 @@ export async function cmdList(opts: ParsedArgs) {
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
         if (fingerprint !== lastFingerprint) {
-          if (lastFingerprint) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+          if (lastFingerprint) outputWrite(`${c.dim}${'─'.repeat(40)}${c.reset}`);
           lastFingerprint = fingerprint;
           memories = sortMemories(memories, opts);
           renderTable(memories, columns, opts, total);

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, out, success, readStdin } from '../output.js';
+import { outputJson, outputFormat, out, outputWrite, success, readStdin } from '../output.js';
 import { MAX_CONTENT_LENGTH, validateContentLength, validateImportance } from '../validate.js';
 
 export async function cmdGet(id: string, opts?: ParsedArgs) {
@@ -14,22 +14,37 @@ export async function cmdGet(id: string, opts?: ParsedArgs) {
     out(result);
   } else if (opts?.raw) {
     const mem = result.memory || result;
-    console.log(mem.content);
+    outputWrite(mem.content);
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const mem = result.memory || result;
+    const row = {
+      id: mem.id || id,
+      content: mem.content || '',
+      importance: mem.importance?.toFixed(2) || '',
+      namespace: mem.namespace || '',
+      tags: mem.metadata?.tags?.join(', ') || '',
+      type: mem.memory_type || '',
+      created: mem.created_at || '',
+      updated: mem.updated_at || '',
+      immutable: mem.immutable ? 'yes' : '',
+      pinned: mem.pinned ? 'yes' : '',
+    };
+    out([row]);
   } else {
     const mem = result.memory || result;
-    console.log(`${c.bold}ID:${c.reset}         ${mem.id || id}`);
-    console.log(`${c.bold}Content:${c.reset}    ${mem.content}`);
-    if (mem.importance !== undefined) console.log(`${c.bold}Importance:${c.reset} ${mem.importance}`);
-    if (mem.namespace) console.log(`${c.bold}Namespace:${c.reset}  ${mem.namespace}`);
-    if (mem.metadata?.tags?.length) console.log(`${c.bold}Tags:${c.reset}       ${mem.metadata.tags.join(', ')}`);
-    if (mem.memory_type) console.log(`${c.bold}Type:${c.reset}       ${mem.memory_type}`);
-    if (mem.created_at) console.log(`${c.bold}Created:${c.reset}    ${new Date(mem.created_at).toLocaleString()}`);
-    if (mem.updated_at) console.log(`${c.bold}Updated:${c.reset}    ${new Date(mem.updated_at).toLocaleString()}`);
-    if (mem.immutable) console.log(`${c.bold}Immutable:${c.reset}  ${c.yellow}yes${c.reset}`);
-    if (mem.pinned) console.log(`${c.bold}Pinned:${c.reset}     ${c.green}yes${c.reset}`);
-    if (mem.expires_at) console.log(`${c.bold}Expires:${c.reset}    ${new Date(mem.expires_at).toLocaleString()}`);
-    if (mem.session_id) console.log(`${c.bold}Session:${c.reset}    ${mem.session_id}`);
-    if (mem.agent_id) console.log(`${c.bold}Agent:${c.reset}      ${mem.agent_id}`);
+    outputWrite(`${c.bold}ID:${c.reset}         ${mem.id || id}`);
+    outputWrite(`${c.bold}Content:${c.reset}    ${mem.content}`);
+    if (mem.importance !== undefined) outputWrite(`${c.bold}Importance:${c.reset} ${mem.importance}`);
+    if (mem.namespace) outputWrite(`${c.bold}Namespace:${c.reset}  ${mem.namespace}`);
+    if (mem.metadata?.tags?.length) outputWrite(`${c.bold}Tags:${c.reset}       ${mem.metadata.tags.join(', ')}`);
+    if (mem.memory_type) outputWrite(`${c.bold}Type:${c.reset}       ${mem.memory_type}`);
+    if (mem.created_at) outputWrite(`${c.bold}Created:${c.reset}    ${new Date(mem.created_at).toLocaleString()}`);
+    if (mem.updated_at) outputWrite(`${c.bold}Updated:${c.reset}    ${new Date(mem.updated_at).toLocaleString()}`);
+    if (mem.immutable) outputWrite(`${c.bold}Immutable:${c.reset}  ${c.yellow}yes${c.reset}`);
+    if (mem.pinned) outputWrite(`${c.bold}Pinned:${c.reset}     ${c.green}yes${c.reset}`);
+    if (mem.expires_at) outputWrite(`${c.bold}Expires:${c.reset}    ${new Date(mem.expires_at).toLocaleString()}`);
+    if (mem.session_id) outputWrite(`${c.bold}Session:${c.reset}    ${mem.session_id}`);
+    if (mem.agent_id) outputWrite(`${c.bold}Agent:${c.reset}      ${mem.agent_id}`);
   }
 }
 

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputQuiet, out, success, progressBar } from '../output.js';
+import { outputJson, outputQuiet, out, outputWrite, success, progressBar } from '../output.js';
 
 export async function cmdMigrate(targetPath: string, opts: ParsedArgs) {
   if (!targetPath) {
@@ -51,7 +51,7 @@ export async function cmdMigrate(targetPath: string, opts: ParsedArgs) {
   }
 
   if (!outputQuiet) {
-    console.log(`${c.blue}ℹ${c.reset} Found ${c.bold}${mdFiles.length}${c.reset} markdown file${mdFiles.length !== 1 ? 's' : ''}`);
+    outputWrite(`${c.blue}ℹ${c.reset} Found ${c.bold}${mdFiles.length}${c.reset} markdown file${mdFiles.length !== 1 ? 's' : ''}`);
   }
 
   const BATCH_SIZE = 5;
@@ -108,13 +108,13 @@ export async function cmdMigrate(targetPath: string, opts: ParsedArgs) {
   if (outputJson) {
     out({ files_found: mdFiles.length, files_processed: filesProcessed, memories_created: totalCreated, memories_deduplicated: totalDeduplicated, errors: totalErrors });
   } else {
-    console.log();
+    outputWrite('');
     success(`Migration complete!`);
-    console.log(`  Files processed:      ${c.cyan}${filesProcessed}${c.reset}`);
-    console.log(`  Memories created:     ${c.green}${totalCreated}${c.reset}`);
-    console.log(`  Deduplicated:         ${c.dim}${totalDeduplicated}${c.reset}`);
+    outputWrite(`  Files processed:      ${c.cyan}${filesProcessed}${c.reset}`);
+    outputWrite(`  Memories created:     ${c.green}${totalCreated}${c.reset}`);
+    outputWrite(`  Deduplicated:         ${c.dim}${totalDeduplicated}${c.reset}`);
     if (totalErrors > 0) {
-      console.log(`  Errors:               ${c.red}${totalErrors}${c.reset}`);
+      outputWrite(`  Errors:               ${c.red}${totalErrors}${c.reset}`);
     }
   }
 }

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -1,7 +1,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, out, table } from '../output.js';
+import { outputJson, out, outputWrite, table } from '../output.js';
 
 /** Try /v1/namespaces endpoint, fall back to client-side pagination */
 async function fetchNamespaces(): Promise<{ name: string; count?: number }[]> {
@@ -48,10 +48,10 @@ export async function cmdNamespace(subcmd: string, rest: string[], opts: ParsedA
     if (outputJson) {
       out({ namespaces: namespaces.map(ns => ns.name), count: namespaces.length });
     } else if (namespaces.length === 0) {
-      console.log(`${c.dim}No namespaces found.${c.reset}`);
+      outputWrite(`${c.dim}No namespaces found.${c.reset}`);
     } else {
       table(namespaces.map(ns => ({ namespace: ns.name })), [{ key: 'namespace', label: 'NAMESPACE', width: 30 }]);
-      console.log(`${c.dim}─ ${namespaces.length} namespace${namespaces.length !== 1 ? 's' : ''}${c.reset}`);
+      outputWrite(`${c.dim}─ ${namespaces.length} namespace${namespaces.length !== 1 ? 's' : ''}${c.reset}`);
     }
   } else if (subcmd === 'stats') {
     const namespaces = await fetchNamespaces();

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -1,27 +1,27 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputTruncate, outputFormat, out, truncate } from '../output.js';
+import { outputJson, outputTruncate, outputFormat, out, outputWrite, truncate } from '../output.js';
 
 /** Render a list of recall memories to stdout (shared between normal and watch mode) */
 function renderMemories(memories: any[], opts: { showId?: boolean } = {}) {
   if (memories.length === 0) {
-    console.log(`${c.dim}No memories found.${c.reset}`);
+    outputWrite(`${c.dim}No memories found.${c.reset}`);
     return;
   }
   for (const mem of memories) {
     const sim = mem.similarity?.toFixed(3) || '???';
     const simColor = (mem.similarity || 0) > 0.8 ? c.green : (mem.similarity || 0) > 0.5 ? c.yellow : c.red;
     const content = outputTruncate ? truncate(mem.content, outputTruncate) : mem.content;
-    console.log(`${simColor}[${sim}]${c.reset} ${content}`);
+    outputWrite(`${simColor}[${sim}]${c.reset} ${content}`);
     if (mem.metadata?.tags?.length) {
-      console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+      outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
     }
     if (opts.showId && mem.id) {
-      console.log(`  ${c.dim}id: ${mem.id}${c.reset}`);
+      outputWrite(`  ${c.dim}id: ${mem.id}${c.reset}`);
     }
   }
-  console.log(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''}${c.reset}`);
+  outputWrite(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''}${c.reset}`);
 }
 
 export async function cmdRecall(query: string, opts: ParsedArgs) {
@@ -36,7 +36,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
     let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
 
-    console.log(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
+    outputWrite(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
     while (true) {
       try {
@@ -45,7 +45,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
         if (fingerprint !== lastFingerprint) {
-          if (lastFingerprint) console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+          if (lastFingerprint) outputWrite(`${c.dim}${'─'.repeat(40)}${c.reset}`);
           lastFingerprint = fingerprint;
           renderMemories(memories);
         }
@@ -75,7 +75,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     const memories = result.memories || [];
     for (const mem of memories) {
-      console.log(mem.content);
+      outputWrite(mem.content);
     }
   } else {
     renderMemories(result.memories || [], { showId: true });

--- a/src/commands/relations.ts
+++ b/src/commands/relations.ts
@@ -1,7 +1,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, out, success, table } from '../output.js';
+import { outputJson, out, outputWrite, success, table } from '../output.js';
 
 export async function cmdRelations(subcmd: string, rest: string[], opts: ParsedArgs) {
   if (subcmd === 'list') {
@@ -12,7 +12,7 @@ export async function cmdRelations(subcmd: string, rest: string[], opts: ParsedA
     } else {
       const relations = result.relations || [];
       if (relations.length === 0) {
-        console.log(`${c.dim}No relations found.${c.reset}`);
+        outputWrite(`${c.dim}No relations found.${c.reset}`);
       } else {
         const rows = relations.map((r: any) => ({
           id: r.id?.slice(0, 8) || '?',

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputFormat, outputTruncate, noTruncate, out, success, info, truncate, table, readStdin } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, truncate, table, readStdin } from '../output.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -20,12 +20,12 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     const memories = result.memories || result.data || [];
     for (const mem of memories) {
-      console.log(mem.content);
+      outputWrite(mem.content);
     }
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     const memories = result.memories || result.data || [];
     const rows = memories.map((m: any) => ({
-      id: m.id?.slice(0, 8) || '?',
+      id: m.id || '',
       content: m.content || '',
       tags: m.metadata?.tags?.join(', ') || '',
     }));
@@ -33,17 +33,17 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else {
     const memories = result.memories || result.data || [];
     if (memories.length === 0) {
-      console.log(`${c.dim}No memories found.${c.reset}`);
+      outputWrite(`${c.dim}No memories found.${c.reset}`);
     } else {
       const truncateWidth = outputTruncate || 80;
       for (const mem of memories) {
         const content = noTruncate ? mem.content : truncate(mem.content || '', truncateWidth);
-        console.log(`${c.cyan}${(mem.id || '?').slice(0, 8)}${c.reset}  ${content}`);
+        outputWrite(`${c.cyan}${(mem.id || '?').slice(0, 8)}${c.reset}  ${content}`);
         if (mem.metadata?.tags?.length) {
-          console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+          outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
         }
       }
-      console.log(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''} (text search, free)${c.reset}`);
+      outputWrite(`${c.dim}─ ${memories.length} result${memories.length !== 1 ? 's' : ''} (text search, free)${c.reset}`);
     }
   }
 }
@@ -60,7 +60,7 @@ export async function cmdContext(query: string, opts: ParsedArgs) {
   } else {
     const context = result.context || result.text || result.content;
     if (context) {
-      console.log(context);
+      outputWrite(context);
     } else {
       out(result);
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,7 +8,7 @@ import { c } from '../colors.js';
 import { API_URL } from '../config.js';
 import { getAccount, getWalletAuthHeader } from '../auth.js';
 import { getRequestTimeout } from '../http.js';
-import { outputJson, outputTruncate, noTruncate, out, success, info, table, truncate } from '../output.js';
+import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, table, truncate } from '../output.js';
 
 async function fetchWithTimeout(url: string, options: RequestInit = {}): Promise<Response> {
   const timeoutMs = getRequestTimeout();
@@ -43,18 +43,25 @@ export async function cmdStatus() {
     const data = await res.json() as any;
     if (outputJson) {
       out(data);
+    } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+      const row = {
+        wallet: data.wallet || '',
+        free_tier_remaining: data.free_tier_remaining ?? 0,
+        free_tier_total: data.free_tier_total ?? 100,
+      };
+      out([row]);
     } else {
-      console.log(`${c.bold}Wallet:${c.reset}     ${data.wallet}`);
       const remaining = data.free_tier_remaining ?? 0;
       const total = data.free_tier_total ?? 100;
       const pct = Math.max(0, Math.min(100, Math.round((remaining / total) * 100)));
       const barLen = 20;
       const filled = Math.max(0, Math.min(barLen, Math.round((remaining / total) * barLen)));
       const bar = `${c.green}${'█'.repeat(filled)}${c.dim}${'░'.repeat(barLen - filled)}${c.reset}`;
-      console.log(`${c.bold}Free tier:${c.reset}  ${remaining}/${total} calls remaining`);
-      console.log(`            ${bar} ${pct}%`);
+      outputWrite(`${c.bold}Wallet:${c.reset}     ${data.wallet}`);
+      outputWrite(`${c.bold}Free tier:${c.reset}  ${remaining}/${total} calls remaining`);
+      outputWrite(`            ${bar} ${pct}%`);
       if (remaining === 0) {
-        console.log(`${c.yellow}→ Next calls will use x402 payment (pay-per-use USDC on Base)${c.reset}`);
+        outputWrite(`${c.yellow}→ Next calls will use x402 payment (pay-per-use USDC on Base)${c.reset}`);
       }
     }
   } else {
@@ -81,25 +88,29 @@ export async function cmdStats(opts: ParsedArgs) {
     tierData = await statusRes.json();
   }
 
+  const statsRow = {
+    total_memories: total,
+    api_url: API_URL,
+    wallet: tierData.wallet || getAccount().address,
+    free_tier_remaining: tierData.free_tier_remaining,
+    free_tier_total: tierData.free_tier_total,
+  };
+
   if (outputJson) {
-    out({
-      total_memories: total,
-      api_url: API_URL,
-      wallet: tierData.wallet || getAccount().address,
-      free_tier_remaining: tierData.free_tier_remaining,
-      free_tier_total: tierData.free_tier_total,
-    });
+    out(statsRow);
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    out([statsRow]);
   } else {
-    console.log(`${c.bold}MemoClaw Stats${c.reset}`);
-    console.log(`${c.dim}${'─'.repeat(40)}${c.reset}`);
-    console.log(`Memories:        ${c.cyan}${total}${c.reset}`);
-    console.log(`API:             ${c.dim}${API_URL}${c.reset}`);
-    console.log(`Wallet:          ${c.dim}${tierData.wallet || getAccount().address}${c.reset}`);
+    outputWrite(`${c.bold}MemoClaw Stats${c.reset}`);
+    outputWrite(`${c.dim}${'─'.repeat(40)}${c.reset}`);
+    outputWrite(`Memories:        ${c.cyan}${total}${c.reset}`);
+    outputWrite(`API:             ${c.dim}${API_URL}${c.reset}`);
+    outputWrite(`Wallet:          ${c.dim}${tierData.wallet || getAccount().address}${c.reset}`);
     if (tierData.free_tier_remaining !== undefined) {
-      console.log(`Free calls left: ${c.cyan}${tierData.free_tier_remaining}${c.reset}/${tierData.free_tier_total}`);
+      outputWrite(`Free calls left: ${c.cyan}${tierData.free_tier_remaining}${c.reset}/${tierData.free_tier_total}`);
     }
     if (opts.namespace) {
-      console.log(`Namespace:       ${c.cyan}${opts.namespace}${c.reset}`);
+      outputWrite(`Namespace:       ${c.cyan}${opts.namespace}${c.reset}`);
     }
   }
 }
@@ -112,8 +123,10 @@ export async function cmdCount(opts: ParsedArgs) {
 
   if (outputJson) {
     out({ count: total, namespace: opts.namespace || null });
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    out([{ count: total, namespace: opts.namespace || '' }]);
   } else {
-    console.log(String(total));
+    outputWrite(String(total));
   }
 }
 
@@ -127,26 +140,37 @@ export async function cmdSuggested(opts: ParsedArgs) {
 
   if (outputJson) {
     out(result);
+  } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
+    const suggestions = result.suggested || [];
+    const rows = suggestions.map((m: any) => ({
+      id: m.id || '',
+      category: m.category || '',
+      review_score: m.review_score?.toFixed(2) || '',
+      content: m.content || '',
+      importance: m.importance?.toFixed(2) || '',
+      tags: m.metadata?.tags?.join(', ') || '',
+    }));
+    out(rows);
   } else {
     if (result.categories) {
       const cats = Object.entries(result.categories)
         .map(([k, v]) => `${c.bold}${k}${c.reset}=${v}`).join('  ');
-      console.log(`Categories: ${cats}`);
-      console.log(`${c.dim}${'─'.repeat(60)}${c.reset}`);
+      outputWrite(`Categories: ${cats}`);
+      outputWrite(`${c.dim}${'─'.repeat(60)}${c.reset}`);
     }
 
     const suggestions = result.suggested || [];
     if (suggestions.length === 0) {
-      console.log(`${c.dim}No suggested memories.${c.reset}`);
+      outputWrite(`${c.dim}No suggested memories.${c.reset}`);
     } else {
       for (const mem of suggestions) {
         const cat = mem.category?.toUpperCase() || '???';
         const catColor = { STALE: c.red, FRESH: c.green, HOT: c.yellow, DECAYING: c.magenta }[cat] || c.gray;
         const maxLen = noTruncate ? Infinity : (outputTruncate || 100);
         const text = truncate(mem.content || '', maxLen);
-        console.log(`${catColor}[${cat}]${c.reset} ${c.dim}(${mem.review_score?.toFixed(2) || '?'})${c.reset} ${text}`);
+        outputWrite(`${catColor}[${cat}]${c.reset} ${c.dim}(${mem.review_score?.toFixed(2) || '?'})${c.reset} ${text}`);
         if (mem.metadata?.tags?.length) {
-          console.log(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
+          outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
         }
       }
     }
@@ -171,11 +195,11 @@ export async function cmdGraph(id: string, opts: ParsedArgs) {
 
   const shortId = (s: string) => s?.slice(0, 8) || '?';
 
-  console.log();
-  console.log(`  ${c.bold}${c.cyan}[${shortId(mem.id)}]${c.reset} ${label(mem)}`);
+  outputWrite('');
+  outputWrite(`  ${c.bold}${c.cyan}[${shortId(mem.id)}]${c.reset} ${label(mem)}`);
 
   if (relations.length === 0) {
-    console.log(`  ${c.dim}  └── (no relations)${c.reset}`);
+    outputWrite(`  ${c.dim}  └── (no relations)${c.reset}`);
   } else {
     for (let i = 0; i < relations.length; i++) {
       const r = relations[i];
@@ -185,8 +209,8 @@ export async function cmdGraph(id: string, opts: ParsedArgs) {
         contradicts: c.red, supersedes: c.yellow, supports: c.green,
         derived_from: c.magenta, related_to: c.blue,
       }[r.relation_type] || c.dim;
-      console.log(`  ${c.dim}  ${branch}──${c.reset} ${typeColor}${r.relation_type}${c.reset} ${c.dim}→${c.reset} ${c.cyan}[${shortId(r.target_id)}]${c.reset}`);
+      outputWrite(`  ${c.dim}  ${branch}──${c.reset} ${typeColor}${r.relation_type}${c.reset} ${c.dim}→${c.reset} ${c.cyan}[${shortId(r.target_id)}]${c.reset}`);
     }
   }
-  console.log();
+  outputWrite('');
 }

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputQuiet, out, success, info, progressBar } from '../output.js';
+import { outputJson, outputQuiet, out, outputWrite, success, info, progressBar } from '../output.js';
 import { validateContentLength, validateImportance } from '../validate.js';
 
 export async function cmdStoreBatch(opts: ParsedArgs, lines: string[]) {
@@ -83,7 +83,7 @@ export async function cmdStore(content: string, opts: ParsedArgs) {
 
   const result = await request('POST', '/v1/store', body) as any;
   if (opts.idOnly) {
-    console.log(result.id || '');
+    outputWrite(result.id || '');
   } else if (outputJson) {
     out(result);
   } else {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1597,3 +1597,164 @@ describe('validateImportance', () => {
   test('rejects "abc"', () => expect(() => validateImportance('abc')).toThrow());
   test('rejects empty', () => expect(() => validateImportance('')).toThrow());
 });
+
+// ─── outputWrite consistency: --format csv/yaml/tsv for commands (Fixes #77, #78) ─────
+
+describe('cmdGet --format csv', () => {
+  test('outputs csv row for a memory', async () => {
+    mockFetchResponse = { memory: { id: 'abc-123-full', content: 'hello world', importance: 0.7, namespace: 'test', metadata: { tags: ['a', 'b'] }, memory_type: 'core', created_at: '2025-01-01', updated_at: '2025-01-02' } };
+    resetOutputState({ format: 'csv' });
+    await cmdGet('abc-123-full');
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('id');
+    expect(joined).toContain('abc-123-full');
+    expect(joined).toContain('hello world');
+  });
+
+  test('outputs yaml for a memory', async () => {
+    mockFetchResponse = { memory: { id: 'abc-yaml', content: 'test content', importance: 0.5 } };
+    resetOutputState({ format: 'yaml' });
+    await cmdGet('abc-yaml');
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('abc-yaml');
+    expect(joined).toContain('test content');
+  });
+});
+
+describe('cmdGet uses outputWrite (--output file support)', () => {
+  test('raw mode uses outputWrite not console.log', async () => {
+    mockFetchResponse = { memory: { id: 'x', content: 'raw content' } };
+    resetOutputState();
+    await cmdGet('x', { _: [], raw: true } as any);
+    expect(consoleOutput.join('')).toContain('raw content');
+  });
+
+  test('detailed view uses outputWrite', async () => {
+    mockFetchResponse = { memory: { id: 'x', content: 'test', importance: 0.5, namespace: 'ns', metadata: { tags: ['t1'] } } };
+    resetOutputState();
+    await cmdGet('x');
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('ID:');
+    expect(joined).toContain('test');
+  });
+});
+
+describe('cmdCount --format csv', () => {
+  test('outputs csv row', async () => {
+    mockFetchResponse = { memories: [], total: 42 };
+    resetOutputState({ format: 'csv' });
+    await cmdCount({ _: [] } as any);
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('count');
+    expect(joined).toContain('42');
+  });
+});
+
+describe('cmdHistory --format csv', () => {
+  test('outputs csv rows for history entries', async () => {
+    mockFetchResponse = { history: [{ id: 'h1-full-id', created_at: '2025-01-01T00:00:00Z', changes: { content: true } }, { id: 'h2-full-id', created_at: '2025-01-02T00:00:00Z', changes: { importance: true, tags: true } }] };
+    resetOutputState({ format: 'csv' });
+    await cmdHistory('abc');
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('id');
+    expect(joined).toContain('h1-full-id');
+    expect(joined).toContain('content');
+  });
+
+  test('empty history uses outputWrite', async () => {
+    mockFetchResponse = { history: [] };
+    resetOutputState();
+    await cmdHistory('abc');
+    expect(consoleOutput.join('')).toContain('No history entries found');
+  });
+});
+
+describe('search uses outputWrite', () => {
+  test('raw mode outputs content via outputWrite', async () => {
+    mockFetchResponse = { memories: [{ id: 's1', content: 'search result' }] };
+    resetOutputState();
+    await cmdSearch('test', { _: [], raw: true } as any);
+    expect(consoleOutput.join('')).toContain('search result');
+  });
+
+  test('csv mode does not truncate IDs', async () => {
+    mockFetchResponse = { memories: [{ id: 'abcdefgh-1234-5678-9012-abcdefghijkl', content: 'test' }] };
+    resetOutputState({ format: 'csv' });
+    await cmdSearch('test', { _: [] } as any);
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('abcdefgh-1234-5678-9012-abcdefghijkl');
+  });
+
+  test('empty search uses outputWrite', async () => {
+    mockFetchResponse = { memories: [] };
+    resetOutputState();
+    await cmdSearch('test', { _: [] } as any);
+    expect(consoleOutput.join('')).toContain('No memories found');
+  });
+});
+
+describe('recall uses outputWrite', () => {
+  test('raw mode outputs content via outputWrite', async () => {
+    mockFetchResponse = { memories: [{ id: 'r1', content: 'recall result', similarity: 0.9 }] };
+    resetOutputState();
+    await cmdRecall('test', { _: [], raw: true } as any);
+    expect(consoleOutput.join('')).toContain('recall result');
+  });
+
+  test('default mode outputs via outputWrite', async () => {
+    mockFetchResponse = { memories: [{ id: 'r2', content: 'recall formatted', similarity: 0.85 }] };
+    resetOutputState();
+    await cmdRecall('test', { _: [] } as any);
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('recall formatted');
+    expect(joined).toContain('0.850');
+  });
+
+  test('empty recall uses outputWrite', async () => {
+    mockFetchResponse = { memories: [] };
+    resetOutputState();
+    await cmdRecall('test', { _: [] } as any);
+    expect(consoleOutput.join('')).toContain('No memories found');
+  });
+});
+
+describe('suggested --format csv', () => {
+  test('outputs csv rows', async () => {
+    mockFetchResponse = { suggested: [{ id: 'sug-1', category: 'stale', review_score: 0.3, content: 'old fact', importance: 0.5, metadata: { tags: ['t'] } }] };
+    resetOutputState({ format: 'csv' });
+    await cmdSuggested({ _: [] } as any);
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('id');
+    expect(joined).toContain('sug-1');
+    expect(joined).toContain('stale');
+  });
+
+  test('default mode uses outputWrite', async () => {
+    mockFetchResponse = { suggested: [{ id: 'sug-2', category: 'hot', review_score: 0.9, content: 'hot fact' }] };
+    resetOutputState();
+    await cmdSuggested({ _: [] } as any);
+    expect(consoleOutput.join('\n')).toContain('hot fact');
+  });
+
+  test('empty suggested uses outputWrite', async () => {
+    mockFetchResponse = { suggested: [] };
+    resetOutputState();
+    await cmdSuggested({ _: [] } as any);
+    expect(consoleOutput.join('')).toContain('No suggested memories');
+  });
+});
+
+describe('graph uses outputWrite', () => {
+  test('renders graph via outputWrite', async () => {
+    let callCount = 0;
+    mockFetchResponse = (url: string) => {
+      if (url.includes('/relations')) return { relations: [{ id: 'r1', relation_type: 'supports', target_id: 'target-1234' }] };
+      return { memory: { id: 'mem-12345678', content: 'graph node' } };
+    };
+    resetOutputState();
+    await cmdGraph('mem-12345678', { _: [] } as any);
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('mem-1234');
+    expect(joined).toContain('supports');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #77 — All commands now use `outputWrite()` instead of `console.log()`, so `--output <file>` works consistently everywhere.

Fixes #78 — Added `--format csv/yaml/tsv` support to `get`, `status`, `stats`, `count`, and `history` commands.

## Changes

### Bug fixes (console.log → outputWrite)
- **memory.ts** — `get` command (detailed view + raw mode)
- **status.ts** — `status`, `stats`, `count`, `suggested`, `graph`
- **list.ts** — `renderTable` empty/footer messages, watch mode
- **recall.ts** — `renderMemories`, watch mode, raw mode
- **search.ts** — raw mode, empty state, context command
- **history.ts** — empty state message
- **store.ts** — `--id-only` output
- **core.ts** — empty state, footer
- **namespace.ts** — empty state, footer
- **relations.ts** — empty state
- **migrate.ts** — progress messages, summary
- **data.ts** — purge abort message

### Enhancements (--format csv/yaml/tsv)
- `get` — structured row with id, content, importance, namespace, tags, type, dates
- `status` — wallet, remaining calls, total
- `stats` — total memories, API URL, wallet, free tier info
- `count` — count + namespace
- `history` — full IDs (not truncated), ISO dates, changed fields

### Also fixed
- `search` csv/tsv no longer truncates IDs to 8 chars

### Tests
- 17 new tests covering format support and outputWrite consistency
- All 392 tests pass

## Note
This PR supersedes the `suggested`/`graph`/`recall`/`search` portions of PR #76. If #76 merges first, this branch may need a rebase to resolve conflicts in `status.ts`, `recall.ts`, and `search.ts`.