### PR TITLE
fix: consistent output helpers in config commands + history args + export help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,7 +200,7 @@ try {
       break;
     case 'history':
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw history <id>');
-      await cmdHistory(rest[0]);
+      await cmdHistory(rest[0], args);
       break;
     case 'migrate': {
       if (!rest[0]) throw new Error('Path required. Usage: memoclaw migrate <path>');

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,16 +9,16 @@ import type { ParsedArgs } from '../args.js';
 import { c } from '../colors.js';
 import { API_URL, PRIVATE_KEY, DEFAULT_NAMESPACE, DEFAULT_TIMEOUT, CONFIG_DIR, CONFIG_FILE, CONFIG_FILE_JSON, ensureConfigDir } from '../config.js';
 import { getAccount } from '../auth.js';
-import { outputJson, out, success, info } from '../output.js';
+import { outputJson, out, outputWrite, outputError, success, info } from '../output.js';
 
 export async function cmdInit(opts: ParsedArgs) {
   const configPath = CONFIG_FILE_JSON;
 
   if (fs.existsSync(configPath) && !opts.force) {
     const existing = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    console.error(`${c.yellow}⚠${c.reset} Config already exists at ${c.cyan}${configPath}${c.reset}`);
-    console.error(`  Wallet: ${c.dim}${existing.address || '(unknown)'}${c.reset}`);
-    console.error(`  Use ${c.bold}--force${c.reset} to overwrite.`);
+    outputError(`${c.yellow}⚠${c.reset} Config already exists at ${c.cyan}${configPath}${c.reset}`);
+    outputError(`  Wallet: ${c.dim}${existing.address || '(unknown)'}${c.reset}`);
+    outputError(`  Use ${c.bold}--force${c.reset} to overwrite.`);
     process.exit(1);
   }
 
@@ -42,17 +42,17 @@ export async function cmdInit(opts: ParsedArgs) {
   if (outputJson) {
     out({ address: newAccount.address, url: apiUrl, configPath });
   } else {
-    console.log();
-    console.log(`${c.green}✓${c.reset} ${c.bold}MemoClaw initialized!${c.reset}`);
-    console.log();
-    console.log(`  ${c.bold}Wallet:${c.reset}  ${c.cyan}${newAccount.address}${c.reset}`);
-    console.log(`  ${c.bold}API:${c.reset}     ${c.dim}${apiUrl}${c.reset}`);
-    console.log(`  ${c.bold}Config:${c.reset}  ${c.dim}${configPath}${c.reset}`);
-    console.log();
-    console.log(`  Your wallet is your identity. No signup needed.`);
-    console.log(`  You get ${c.bold}100 free API calls${c.reset}, then x402 micropayments.`);
-    console.log();
-    console.log(`  ${c.dim}Try: memoclaw store "Hello, MemoClaw!"${c.reset}`);
+    outputWrite('');
+    outputWrite(`${c.green}✓${c.reset} ${c.bold}MemoClaw initialized!${c.reset}`);
+    outputWrite('');
+    outputWrite(`  ${c.bold}Wallet:${c.reset}  ${c.cyan}${newAccount.address}${c.reset}`);
+    outputWrite(`  ${c.bold}API:${c.reset}     ${c.dim}${apiUrl}${c.reset}`);
+    outputWrite(`  ${c.bold}Config:${c.reset}  ${c.dim}${configPath}${c.reset}`);
+    outputWrite('');
+    outputWrite(`  Your wallet is your identity. No signup needed.`);
+    outputWrite(`  You get ${c.bold}100 free API calls${c.reset}, then x402 micropayments.`);
+    outputWrite('');
+    outputWrite(`  ${c.dim}Try: memoclaw store "Hello, MemoClaw!"${c.reset}`);
   }
 }
 
@@ -69,12 +69,12 @@ export async function cmdConfig(subcmd: string, rest: string[]) {
 
     fs.writeFileSync(configPath, yaml.dump(sampleConfig, { indent: 2 }));
     success(`Config file created at ${c.cyan}${configPath}${c.reset}`);
-    console.log(`${c.dim}Edit this file and remove the privateKey line (set via MEMOCLAW_PRIVATE_KEY env var)${c.reset}`);
+    outputWrite(`${c.dim}Edit this file and remove the privateKey line (set via MEMOCLAW_PRIVATE_KEY env var)${c.reset}`);
     return;
   }
 
   if (subcmd === 'path') {
-    console.log(CONFIG_FILE);
+    outputWrite(CONFIG_FILE);
     return;
   }
 
@@ -90,13 +90,13 @@ export async function cmdConfig(subcmd: string, rest: string[]) {
     if (outputJson) {
       out(config);
     } else {
-      console.log(`${c.bold}MemoClaw Configuration${c.reset}`);
-      console.log(`${c.dim}${'─'.repeat(50)}${c.reset}`);
+      outputWrite(`${c.bold}MemoClaw Configuration${c.reset}`);
+      outputWrite(`${c.dim}${'─'.repeat(50)}${c.reset}`);
       for (const [key, val] of Object.entries(config)) {
         const isSet = !val.includes('not set');
-        console.log(`  ${c.cyan}${key.padEnd(24)}${c.reset} ${isSet ? val : `${c.dim}${val}${c.reset}`}`);
+        outputWrite(`  ${c.cyan}${key.padEnd(24)}${c.reset} ${isSet ? val : `${c.dim}${val}${c.reset}`}`);
       }
-      console.log(`\n${c.dim}Set via environment variables or .env file${c.reset}`);
+      outputWrite(`\n${c.dim}Set via environment variables or .env file${c.reset}`);
     }
   } else if (subcmd === 'check') {
     const issues: string[] = [];
@@ -129,7 +129,7 @@ export async function cmdConfig(subcmd: string, rest: string[]) {
         success(`API reachable at ${c.dim}${API_URL}${c.reset}`);
       } else {
         for (const issue of issues) {
-          console.log(`${c.red}✗${c.reset} ${issue}`);
+          outputWrite(`${c.red}✗${c.reset} ${issue}`);
         }
       }
     }

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -2,11 +2,12 @@
  * History command: view change history for a memory
  */
 
+import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, out, outputWrite, table } from '../output.js';
 
-export async function cmdHistory(id: string) {
+export async function cmdHistory(id: string, opts?: ParsedArgs) {
   const result = await request('GET', `/v1/memories/${id}/history`) as any;
   if (outputJson) {
     out(result);

--- a/src/help.ts
+++ b/src/help.ts
@@ -100,10 +100,13 @@ Export all memories as JSON. Useful for backups.
 
   ${c.dim}memoclaw export > backup.json${c.reset}
   ${c.dim}memoclaw export --namespace project1 > project1.json${c.reset}
+  ${c.dim}memoclaw export --format csv > backup.csv${c.reset}
+  ${c.dim}memoclaw export --format yaml > backup.yaml${c.reset}
 
 Options:
   --namespace <name>     Filter by namespace
-  --limit <n>            Max per page (default: 100)`,
+  --limit <n>            Max per page (default: 1000)
+  --format <fmt>         Output format: json, csv, tsv, yaml`,
 
       import: `${c.bold}memoclaw import${c.reset} [options]
 


### PR DESCRIPTION
## Changes

**Fixes:** #81, #82, #83

### 1. config.ts: Use outputWrite/outputError instead of console.log (#81)
All `console.log` and `console.error` calls in `config.ts` replaced with `outputWrite`/`outputError` from the shared output layer. This means `--output <file>` now works with `init`, `config show`, `config check`, and `config path`.

### 2. history: Accept ParsedArgs (#83)
`cmdHistory` now accepts an optional `ParsedArgs` parameter, and `cli.ts` passes `args` through. This enables future format/raw support for the history command.

### 3. export help text: Add format options (#82)
Updated `export` help text to document `--format csv|tsv|yaml` support and corrected the default limit from 100 to 1000.

## Tests
All 399 tests pass. Build succeeds.