### PR TITLE
feat: whoami command + importance validation hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -157,6 +157,17 @@ try {
     case 'suggested':
       await cmdSuggested(args);
       break;
+    case 'whoami': {
+      const { getAccount } = await import('./auth.js');
+      const { out, outputJson, outputWrite } = await import('./output.js');
+      const acct = getAccount();
+      if (outputJson) {
+        out({ address: acct.address });
+      } else {
+        outputWrite(acct.address);
+      }
+      break;
+    }
     case 'status':
       await cmdStatus();
       break;

--- a/src/help.ts
+++ b/src/help.ts
@@ -336,6 +336,14 @@ View the change history for a memory (FREE).
   ${c.dim}memoclaw history 550e8400-e29b-41d4-a716-446655440000${c.reset}
   ${c.dim}memoclaw history abc123 --json${c.reset}`,
 
+      whoami: `${c.bold}memoclaw whoami${c.reset}
+
+Print your wallet address. Useful for scripting.
+
+  ${c.dim}memoclaw whoami${c.reset}
+  ${c.dim}WALLET=$(memoclaw whoami)${c.reset}
+  ${c.dim}memoclaw whoami --json${c.reset}`,
+
       namespace: `${c.bold}memoclaw namespace${c.reset} [list|stats]
 
 Manage and view namespaces.
@@ -379,6 +387,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}relations${c.reset} <sub>        Manage memory relations
   ${c.cyan}core${c.reset}                   List core memories (free)
   ${c.cyan}suggested${c.reset}              Get suggested memories for review
+  ${c.cyan}whoami${c.reset}                 Print your wallet address
   ${c.cyan}status${c.reset}                 Check account & free tier info
   ${c.cyan}stats${c.reset}                  Memory statistics
   ${c.cyan}export${c.reset}                 Export all memories as JSON

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -16,7 +16,10 @@ export function validateContentLength(content: string, label = 'Content') {
 export function validateImportance(value: string): number {
   const n = parseFloat(value);
   if (isNaN(n) || n < 0 || n > 1) {
-    throw new Error(`Importance must be a number between 0 and 1 (got "${value}")`);
+    throw new Error(
+      `Importance must be a number between 0 and 1 (got "${value}")\n` +
+      `Hint: --importance takes a numeric value, e.g. --importance 0.8`
+    );
   }
   return n;
 }


### PR DESCRIPTION
## Changes

### whoami command (Fixes #85)
- New `memoclaw whoami` command prints wallet address to stdout
- Supports `--json` for scripting: `{"address": "0x..."}`
- Added to help text and command listing
- Useful for: `WALLET=$(memoclaw whoami)`

### Importance validation hint (Fixes #86)
- Improved error message when `--importance` receives a non-numeric value
- Now includes a hint line: `Hint: --importance takes a numeric value, e.g. --importance 0.8`

**Tests:** All 399 tests pass. Build succeeds.