### PR TITLE
feat: support --id-only flag for store --batch

### DIFF
--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -49,11 +49,15 @@ export async function cmdStoreBatch(opts: ParsedArgs, lines: string[]) {
   // Batch in chunks of 100
   const BATCH_SIZE = 100;
   let stored = 0;
+  const allIds: string[] = [];
 
   for (let i = 0; i < memories.length; i += BATCH_SIZE) {
     const chunk = memories.slice(i, i + BATCH_SIZE);
     const result = await request('POST', '/v1/store/batch', { memories: chunk }) as any;
     stored += result.stored ?? chunk.length;
+    if (result.ids && Array.isArray(result.ids)) {
+      allIds.push(...result.ids);
+    }
     if (!outputQuiet) {
       process.stderr.write(`\r  ${progressBar(Math.min(i + BATCH_SIZE, memories.length), memories.length)}`);
     }
@@ -61,8 +65,14 @@ export async function cmdStoreBatch(opts: ParsedArgs, lines: string[]) {
 
   if (!outputQuiet) process.stderr.write('\n');
 
-  if (outputJson) {
-    out({ stored, total: memories.length });
+  if (opts.idOnly) {
+    if (allIds.length > 0) {
+      outputWrite(allIds.join('\n'));
+    } else {
+      info(`Stored ${stored} memories (batch API did not return individual IDs)`);
+    }
+  } else if (outputJson) {
+    out({ stored, total: memories.length, ...(allIds.length > 0 ? { ids: allIds } : {}) });
   } else {
     success(`Stored ${c.cyan}${stored}${c.reset} memories via batch`);
   }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1296,6 +1296,54 @@ describe('store batch flags', () => {
     expect(body.memories[0].expires_at).toBe('2026-12-31');
     expect(body.memories[1].session_id).toBe('sess-1');
   });
+
+  test('batch --id-only outputs IDs one per line when API returns ids', async () => {
+    const { cmdStoreBatch } = await import('../src/commands/store.js');
+    mockFetchResponse = { stored: 2, ids: ['id-aaa', 'id-bbb'] };
+    resetOutputState();
+    captureConsole();
+
+    await cmdStoreBatch(
+      { _: [], idOnly: true, quiet: true } as any,
+      ['memory one', 'memory two']
+    );
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('id-aaa');
+    expect(output).toContain('id-bbb');
+  });
+
+  test('batch --id-only shows info message when API returns no ids', async () => {
+    const { cmdStoreBatch } = await import('../src/commands/store.js');
+    mockFetchResponse = { stored: 2 };
+    resetOutputState();
+    captureConsole();
+
+    await cmdStoreBatch(
+      { _: [], idOnly: true } as any,
+      ['memory one', 'memory two']
+    );
+
+    const allOutput = [...consoleOutput, ...consoleErrors].join('\n');
+    expect(allOutput).toContain('Stored 2 memories');
+  });
+
+  test('batch --json includes ids array when API returns them', async () => {
+    const { cmdStoreBatch } = await import('../src/commands/store.js');
+    mockFetchResponse = { stored: 2, ids: ['id-aaa', 'id-bbb'] };
+    resetOutputState({ json: true });
+    captureConsole();
+
+    await cmdStoreBatch(
+      { _: [], quiet: true } as any,
+      ['memory one', 'memory two']
+    );
+
+    const output = consoleOutput.join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed.ids).toEqual(['id-aaa', 'id-bbb']);
+    expect(parsed.stored).toBe(2);
+  });
 });
 
 describe('list tags filter', () => {


### PR DESCRIPTION
Add `--id-only` support to batch store operations.

**Behavior:**
- When the batch API returns `ids` in the response, `--id-only` outputs them one per line (pipe-friendly)
- When the API doesn't return IDs, shows an info message instead of failing silently
- JSON output (`--json`) now includes the `ids` array when available

**Example:**
```bash
echo -e "memory one\nmemory two" | memoclaw store --batch --id-only
# id-aaa
# id-bbb
```

**Tests:** 3 new tests added (418 total, all passing).

Fixes #99