### PR TITLE
fix: audit bugs — ingest/extract limit, update flags, search truncation, arg parsing

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -74,7 +74,9 @@ export function parseArgs(args: string[]): ParsedArgs {
           i++;
         } else {
           const next = args[i + 1];
-          if (next !== undefined && !next.startsWith('-')) {
+          // Match long-flag behavior: only reject values starting with '--'
+          // (single '-' is common in tags, namespaces, etc.)
+          if (next !== undefined && (!next.startsWith('--') || /^--?\d/.test(next))) {
             result[key] = next;
             i += 2;
           } else {
@@ -100,7 +102,7 @@ export function parseArgs(args: string[]): ParsedArgs {
             } else if (ci === chars.length - 1) {
               // Last flag can take a value
               const next = args[i + 1];
-              if (next !== undefined && !next.startsWith('-')) {
+              if (next !== undefined && (!next.startsWith('--') || /^--?\d/.test(next))) {
                 result[key] = next;
                 i++; // extra bump for consumed value
               } else {

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -91,6 +91,8 @@ export async function cmdUpdate(id: string, opts: ParsedArgs) {
   if (opts.expiresAt) body.expires_at = opts.expiresAt;
   if (opts.pinned !== undefined) body.pinned = opts.pinned === 'true' || opts.pinned === true;
   if (opts.immutable !== undefined) body.immutable = opts.immutable === 'true' || opts.immutable === true;
+  if (opts.sessionId) body.session_id = opts.sessionId;
+  if (opts.agentId) body.agent_id = opts.agentId;
 
   if (Object.keys(body).length === 0) {
     throw new Error('No fields to update. Use --content, --importance, --tags, etc.');

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -6,7 +6,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, truncate, table, readStdin } from '../output.js';
-import { validateContentLength } from '../validate.js';
+import { validateContentLength, validateBulkContentLength } from '../validate.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -36,9 +36,8 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     if (memories.length === 0) {
       outputWrite(`${c.dim}No memories found.${c.reset}`);
     } else {
-      const truncateWidth = outputTruncate || 80;
       for (const mem of memories) {
-        const content = noTruncate ? mem.content : truncate(mem.content || '', truncateWidth);
+        const content = (noTruncate || !outputTruncate) ? (mem.content || '') : truncate(mem.content || '', outputTruncate);
         outputWrite(`${c.cyan}${(mem.id || '?').slice(0, 8)}${c.reset}  ${content}`);
         if (mem.metadata?.tags?.length) {
           outputWrite(`  ${c.dim}tags: ${mem.metadata.tags.join(', ')}${c.reset}`);
@@ -69,7 +68,7 @@ export async function cmdContext(query: string, opts: ParsedArgs) {
 }
 
 export async function cmdExtract(text: string, opts: ParsedArgs) {
-  validateContentLength(text, 'Extract text');
+  validateBulkContentLength(text, 'Extract text');
   const body: Record<string, any> = { text };
   if (opts.namespace) body.namespace = opts.namespace;
   if (opts.sessionId) body.session_id = opts.sessionId;
@@ -100,7 +99,7 @@ export async function cmdIngest(opts: ParsedArgs) {
   }
 
   if (!body.text) throw new Error('Text required (use --text, --file, or pipe via stdin)');
-  validateContentLength(body.text, 'Ingest text');
+  validateBulkContentLength(body.text, 'Ingest text');
 
   const result = await request('POST', '/v1/ingest', body) as any;
   if (outputJson) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -165,7 +165,9 @@ Options:
   --memory-type <type>   Memory type
   --namespace <name>     Move to namespace
   --expires-at <date>    Expiration date
-  --pinned <true|false>  Pin/unpin memory`,
+  --pinned <true|false>  Pin/unpin memory
+  --session-id <id>      Session identifier
+  --agent-id <id>        Agent identifier`,
 
       delete: `${c.bold}memoclaw delete${c.reset} <id>
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -3,6 +3,7 @@
  */
 
 export const MAX_CONTENT_LENGTH = 8192;
+export const MAX_BULK_CONTENT_LENGTH = 100_000;
 
 export function validateContentLength(content: string, label = 'Content') {
   if (!content.trim()) {
@@ -10,6 +11,19 @@ export function validateContentLength(content: string, label = 'Content') {
   }
   if (content.length > MAX_CONTENT_LENGTH) {
     throw new Error(`${label} exceeds the ${MAX_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
+  }
+}
+
+/**
+ * Validate content for bulk-processing commands (ingest, extract) that accept
+ * longer text. Only checks for empty/whitespace; uses a generous upper limit.
+ */
+export function validateBulkContentLength(content: string, label = 'Content') {
+  if (!content.trim()) {
+    throw new Error(`${label} cannot be empty or whitespace-only`);
+  }
+  if (content.length > MAX_BULK_CONTENT_LENGTH) {
+    throw new Error(`${label} exceeds the ${MAX_BULK_CONTENT_LENGTH} character limit (got ${content.length} chars)`);
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1344,4 +1344,26 @@ describe('whoami', () => {
     expect(result._).toEqual(['whoami']);
     expect(result.json).toBe(true);
   });
+
+  test('short flag -t accepts values starting with single hyphen', () => {
+    const result = parseArgs(['-t', '-experimental']);
+    expect(result.tags).toBe('-experimental');
+  });
+
+  test('short flag -n accepts hyphenated values', () => {
+    const result = parseArgs(['-n', '-my-namespace']);
+    expect(result.namespace).toBe('-my-namespace');
+  });
+
+  test('short flag still rejects values starting with --', () => {
+    const result = parseArgs(['-n', '--json']);
+    expect(result.namespace).toBe(true);
+    expect(result.json).toBe(true);
+  });
+
+  test('combined short flags: last flag accepts hyphenated value', () => {
+    const result = parseArgs(['-jn', '-my-ns']);
+    expect(result.json).toBe(true);
+    expect(result.namespace).toBe('-my-ns');
+  });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -109,7 +109,7 @@ const { cmdRelations } = await import('../src/commands/relations.js');
 const { cmdNamespace } = await import('../src/commands/namespace.js');
 const { cmdExport, cmdImport, cmdPurge } = await import('../src/commands/data.js');
 const { cmdWhoami } = await import('../src/commands/whoami.js');
-const { validateContentLength, validateImportance } = await import('../src/validate.js');
+const { validateContentLength, validateBulkContentLength, validateImportance } = await import('../src/validate.js');
 
 // ─── Setup ───────────────────────────────────────────────────────────────────
 
@@ -682,6 +682,15 @@ describe('cmdUpdate', () => {
       restoreConsole();
     }
   });
+
+  test('passes session-id and agent-id to API', async () => {
+    mockFetchResponse = { id: 'abc' };
+    await cmdUpdate('abc', { _: [], content: 'updated', sessionId: 'sess-1', agentId: 'agent-1' } as any);
+    const body = getLastBody();
+    expect(body.session_id).toBe('sess-1');
+    expect(body.agent_id).toBe('agent-1');
+    restoreConsole();
+  });
 });
 
 // ─── Count ───────────────────────────────────────────────────────────────────
@@ -910,8 +919,16 @@ describe('cmdExtract', () => {
     restoreConsole();
   });
 
-  test('rejects text longer than 8192 chars', async () => {
+  test('accepts text longer than 8192 chars (bulk limit is 100k)', async () => {
+    mockFetchResponse = { memories: [] };
     const longText = 'a'.repeat(10000);
+    await cmdExtract(longText, { _: [] } as any);
+    expect(getLastBody().text).toBe(longText);
+    restoreConsole();
+  });
+
+  test('rejects text longer than 100,000 chars', async () => {
+    const longText = 'a'.repeat(100_001);
     await expect(cmdExtract(longText, { _: [] } as any)).rejects.toThrow('exceeds');
     restoreConsole();
   });
@@ -945,8 +962,16 @@ describe('cmdIngest', () => {
     restoreConsole();
   });
 
-  test('rejects text longer than 8192 chars', async () => {
+  test('accepts text longer than 8192 chars (bulk limit is 100k)', async () => {
+    mockFetchResponse = { memories_created: 1 };
     const longText = 'a'.repeat(10000);
+    await cmdIngest({ _: [], text: longText } as any);
+    expect(getLastBody().text).toBe(longText);
+    restoreConsole();
+  });
+
+  test('rejects text longer than 100,000 chars', async () => {
+    const longText = 'a'.repeat(100_001);
     await expect(cmdIngest({ _: [], text: longText } as any)).rejects.toThrow('exceeds');
     restoreConsole();
   });
@@ -1276,6 +1301,32 @@ describe('validateContentLength', () => {
 
   test('rejects whitespace-only content', () => {
     expect(() => validateContentLength('   \n\t  ')).toThrow('empty');
+  });
+});
+
+describe('validateBulkContentLength', () => {
+  test('allows text up to 100,000 chars', () => {
+    expect(() => validateBulkContentLength('x'.repeat(100_000))).not.toThrow();
+  });
+
+  test('allows text over 8192 chars (ingest/extract use case)', () => {
+    expect(() => validateBulkContentLength('x'.repeat(50_000))).not.toThrow();
+  });
+
+  test('throws over 100,000 chars', () => {
+    expect(() => validateBulkContentLength('x'.repeat(100_001))).toThrow('100000');
+  });
+
+  test('rejects empty content', () => {
+    expect(() => validateBulkContentLength('')).toThrow('empty');
+  });
+
+  test('rejects whitespace-only content', () => {
+    expect(() => validateBulkContentLength('   \n\t  ')).toThrow('empty');
+  });
+
+  test('uses custom label', () => {
+    expect(() => validateBulkContentLength('', 'Ingest text')).toThrow('Ingest text');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes 4 bugs found during code audit:

### Bug fixes

1. **Ingest/Extract content length too restrictive** (Fixes #103)
   - `ingest` and `extract` commands used `MAX_CONTENT_LENGTH` (8192 chars), which is too small for these bulk-text commands
   - Added `validateBulkContentLength()` with a 100k char limit
   - `store`/`update` still use the 8192 limit (single memory)

2. **`update` command missing `--session-id` and `--agent-id`** (Fixes #104)
   - `store` supported these flags but `update` silently ignored them
   - Added pass-through to the PATCH request body
   - Updated help text

3. **`search` hardcodes 80-char truncation** (Fixes #105)
   - When no `--truncate` flag was set, search defaulted to 80 chars
   - Now respects the user's choice: no truncation unless explicitly requested

4. **Short flags reject values starting with `-`** (Fixes #106)
   - `-t -experimental` failed while `--tags -experimental` worked
   - Aligned short flag parsing with long flag behavior (only reject `--` prefix)

### Tests

- Added 10 new tests covering all fixes
- Updated 2 existing tests for the new bulk content limit
- All 431 tests pass