### PR TITLE
fix: list --pinned/--immutable false incorrectly filters for true

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -115,8 +115,12 @@ export async function cmdList(opts: ParsedArgs) {
   if (opts.memoryType) params.set('memory_type', opts.memoryType);
   if (opts.agentId) params.set('agent_id', opts.agentId);
   if (opts.sessionId) params.set('session_id', opts.sessionId);
-  if (opts.pinned) params.set('pinned', 'true');
-  if (opts.immutable) params.set('immutable', 'true');
+  if (opts.pinned !== undefined && opts.pinned !== false) {
+    params.set('pinned', String(opts.pinned !== 'false'));
+  }
+  if (opts.immutable !== undefined && opts.immutable !== false) {
+    params.set('immutable', String(opts.immutable !== 'false'));
+  }
 
   // Watch mode
   if (opts.watch) {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1568,6 +1568,36 @@ describe('list pinned/immutable filters', () => {
     expect(url).toContain('pinned=true');
     expect(url).toContain('immutable=true');
   });
+
+  test('--pinned false sends pinned=false (#108)', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], pinned: 'false' } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('pinned=false');
+  });
+
+  test('--immutable false sends immutable=false (#108)', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], immutable: 'false' } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('immutable=false');
+  });
+
+  test('--pinned (no value) still sends pinned=true (#108)', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdList({ _: [], pinned: true } as any);
+    restoreConsole();
+    const url = allFetches.find(f => f.url.includes('/v1/memories'))?.url || '';
+    expect(url).toContain('pinned=true');
+  });
 });
 
 // ─── #60: search format support ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`memoclaw list --pinned false` was sending `pinned=true` to the API because the truthy check on `opts.pinned` treated the string `"false"` as truthy.

## Changes

- **src/commands/list.ts**: Changed filter logic to properly handle string `'false'` values for `--pinned` and `--immutable` flags
- **test/commands.test.ts**: Added 3 tests covering `--pinned false`, `--immutable false`, and confirming `--pinned` (no value) still works

## Testing

All 434 tests pass.

Fixes #108