### PR TITLE
fix: graceful error for non-JSON API responses

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -108,9 +108,19 @@ export async function request(method: string, path: string, body: any = null) {
     }
   }
 
-  const data = await res.json();
+  const text = await res.text();
+  let data: any;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(
+      `Server returned non-JSON response (HTTP ${res.status}).\n` +
+      `This usually means the API is down or behind a proxy.\n` +
+      `Response: ${text.slice(0, 200)}`
+    );
+  }
   if (!res.ok) {
-    throw new Error((data as any).error?.message || `HTTP ${res.status}`);
+    throw new Error(data.error?.message || `HTTP ${res.status}`);
   }
   return data;
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -44,6 +44,7 @@ function setupMockFetch() {
       ok: true,
       status: 200,
       json: async () => responseData,
+      text: async () => JSON.stringify(responseData),
       headers: new Headers({ 'content-type': 'application/json' }),
       clone: () => ({
         json: async () => responseData,


### PR DESCRIPTION
## Summary

When the API returns non-JSON responses (e.g., HTML from a reverse proxy 502 Bad Gateway), the CLI now shows a helpful error instead of a confusing `Unexpected token < in JSON at position 0`.

## Changes

- **src/http.ts**: Parse response as text first, then try JSON.parse with a graceful fallback error message
- **test/commands.test.ts**: Updated mock fetch to include `text()` method

## Before
```
Error: Unexpected token < in JSON at position 0
```

## After
```
Error: Server returned non-JSON response (HTTP 502).
This usually means the API is down or behind a proxy.
Response: <html><body><h1>502 Bad Gateway</h1>...
```

## Testing

All 431 tests pass.

Fixes #109