### PR TITLE
fix: browse TTY check + -M short flag for --memory-type

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -43,6 +43,7 @@ const SHORT_FLAGS: Record<string, string> = {
   '-k': 'columns',
   '-O': 'output',
   '-F': 'field',
+  '-M': 'memoryType',
 };
 
 export function parseArgs(args: string[]): ParsedArgs {

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -9,6 +9,10 @@ import { cmdDelete } from './memory.js';
 import { cmdStats } from './status.js';
 
 export async function cmdBrowse(opts: ParsedArgs) {
+  if (!process.stdin.isTTY) {
+    throw new Error('Interactive browser requires a terminal. Use individual commands instead (e.g. memoclaw list, memoclaw recall).');
+  }
+
   const readline = await import('readline');
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   const prompt = (q: string): Promise<string> => new Promise(r => rl.question(q, r));

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -23,6 +23,8 @@ _memoclaw() {
     COMPREPLY=( $(compgen -W "\$flags" -- "\$cur") )
   elif [[ "\$prev" == "--format" || "\$prev" == "-f" ]]; then
     COMPREPLY=( $(compgen -W "json table csv yaml" -- "\$cur") )
+  elif [[ "\$prev" == "--memory-type" || "\$prev" == "-M" ]]; then
+    COMPREPLY=( $(compgen -W "core episodic semantic procedural" -- "\$cur") )
   elif [[ "\${COMP_WORDS[1]}" == "relations" && "\$COMP_CWORD" -eq 2 ]]; then
     COMPREPLY=( $(compgen -W "list create delete" -- "\$cur") )
   elif [[ "\${COMP_WORDS[1]}" == "config" && "\$COMP_CWORD" -eq 2 ]]; then
@@ -49,6 +51,10 @@ _memoclaw() {
       config)     _values 'subcommand' show check init path ;;
       namespace)  _values 'subcommand' list stats ;;
       completions) _values 'shell' bash zsh fish ;;
+      store|list|update) 
+        case \${words[CURRENT-1]} in
+          --memory-type|-M) _values 'type' core episodic semantic procedural ;;
+        esac ;;
       *)
         if [[ "\$PREFIX" == -* ]]; then
           _describe 'flag' flags

--- a/src/help.ts
+++ b/src/help.ts
@@ -443,6 +443,7 @@ ${c.bold}Global Options:${c.reset}
   --raw                  Raw output (content only, for piping)
   --wide                 Use wider columns in table output
   --force                Skip confirmation prompts
+  -M, --memory-type <t>  Memory type (core, episodic, semantic, procedural)
   -T, --timeout <sec>    Request timeout (default: 30)
 
 ${c.bold}Environment:${c.reset}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -795,6 +795,22 @@ describe('new short flags', () => {
     const result = parseArgs(['list', '--timeout=120']);
     expect(result.timeout).toBe('120');
   });
+
+  test('-M for memoryType', () => {
+    const result = parseArgs(['store', 'test', '-M', 'core']);
+    expect(result.memoryType).toBe('core');
+    expect(result._).toEqual(['store', 'test']);
+  });
+
+  test('--memory-type maps to memoryType', () => {
+    const result = parseArgs(['list', '--memory-type', 'episodic']);
+    expect(result.memoryType).toBe('episodic');
+  });
+
+  test('-M=semantic works', () => {
+    const result = parseArgs(['store', 'test', '-M=semantic']);
+    expect(result.memoryType).toBe('semantic');
+  });
 });
 
 // ─── Sort and column selection ────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Bug Fix: Browse TTY check (Fixes #116)
- `memoclaw browse` now throws a helpful error when stdin is not a TTY
- Prevents hanging when input is piped (e.g., `echo '' | memoclaw browse`)

### Enhancement: -M short flag (Fixes #119)
- Added `-M` as short alias for `--memory-type`
- Updated bash/zsh completions with memory type values (`core`, `episodic`, `semantic`, `procedural`)
- Documented in global help text

### Tests
- 3 new tests for `-M` flag parsing (437 total, all passing)