### PR TITLE
feat: add upgrade command to check for and install CLI updates

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -11,7 +11,7 @@ export interface ParsedArgs {
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
   'force', 'count', 'wide', 'pretty', 'watch', 'interactive', 'yes', 'reverse',
-  'noTruncate', 'batch', 'idOnly', 'noRetry', 'all',
+  'noTruncate', 'batch', 'idOnly', 'noRetry', 'all', 'check',
 ]);
 
 /** Short flag aliases */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import { cmdHistory } from './commands/history.js';
 import { cmdDiff } from './commands/diff.js';
 import { cmdCore } from './commands/core.js';
 import { cmdWhoami } from './commands/whoami.js';
+import { cmdUpgrade } from './commands/upgrade.js';
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
@@ -234,6 +235,9 @@ try {
       await cmdMigrate(rest[0], args);
       break;
     }
+    case 'upgrade':
+      await cmdUpgrade(args);
+      break;
     case 'help':
       printHelp(rest[0]);
       break;

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,7 +1,7 @@
 export async function cmdCompletions(shell: string) {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
-    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'whoami', 'help'];
+    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'whoami', 'upgrade', 'help'];
 
   const globalFlags = ['--help', '--version', '--json', '--quiet', '--namespace', '--limit', '--offset',
     '--tags', '--format', '--pretty', '--watch', '--raw', '--force', '--output', '--truncate',

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,199 @@
+/**
+ * Upgrade command — check for and install CLI updates
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { c } from '../colors.js';
+import { VERSION, CONFIG_DIR, ensureConfigDir } from '../config.js';
+import { outputJson, out, outputWrite, success, info, warn } from '../output.js';
+import type { ParsedArgs } from '../args.js';
+
+const CACHE_FILE = path.join(CONFIG_DIR, 'last-version-check.json');
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface VersionCheckResult {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+  latestPublishedAt?: string;
+}
+
+/** Fetch latest version from npm registry */
+export async function fetchLatestVersion(): Promise<{ version: string; publishedAt?: string }> {
+  const res = await fetch('https://registry.npmjs.org/memoclaw/latest');
+  if (!res.ok) throw new Error(`npm registry returned ${res.status}`);
+  const data = await res.json() as any;
+  return {
+    version: data.version,
+    publishedAt: data.time?.[data.version] || undefined,
+  };
+}
+
+/** Compare two semver strings. Returns -1, 0, or 1. */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const va = pa[i] || 0;
+    const vb = pb[i] || 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/** Read cached version check */
+function readCache(): { version: string; checkedAt: number } | null {
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const data = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+      if (data.version && data.checkedAt) return data;
+    }
+  } catch {}
+  return null;
+}
+
+/** Write cache */
+function writeCache(version: string) {
+  try {
+    ensureConfigDir();
+    fs.writeFileSync(CACHE_FILE, JSON.stringify({ version, checkedAt: Date.now() }));
+  } catch {}
+}
+
+/** Check for updates (uses cache if fresh) */
+export async function checkForUpdate(forceRefresh = false): Promise<VersionCheckResult> {
+  if (!forceRefresh) {
+    const cached = readCache();
+    if (cached && Date.now() - cached.checkedAt < CACHE_TTL_MS) {
+      return {
+        current: VERSION,
+        latest: cached.version,
+        updateAvailable: compareSemver(VERSION, cached.version) < 0,
+      };
+    }
+  }
+
+  const { version: latest, publishedAt } = await fetchLatestVersion();
+  writeCache(latest);
+
+  return {
+    current: VERSION,
+    latest,
+    updateAvailable: compareSemver(VERSION, latest) < 0,
+    latestPublishedAt: publishedAt,
+  };
+}
+
+/** Install the latest version */
+export function installUpdate(): { success: boolean; output: string } {
+  try {
+    const output = execSync('npm install -g memoclaw@latest 2>&1', {
+      encoding: 'utf-8',
+      timeout: 60_000,
+    });
+    return { success: true, output: output.trim() };
+  } catch (err: any) {
+    return { success: false, output: err.message || String(err) };
+  }
+}
+
+export async function cmdUpgrade(opts: ParsedArgs) {
+  const checkOnly = !!opts.check;
+  const autoYes = !!opts.yes || !!opts.force;
+
+  let result: VersionCheckResult;
+  try {
+    result = await checkForUpdate(true);
+  } catch (err: any) {
+    if (outputJson) {
+      out({ error: `Failed to check for updates: ${err.message}` });
+    } else {
+      outputWrite(`${c.red}Error:${c.reset} Failed to check for updates: ${err.message}`);
+    }
+    process.exit(1);
+    return; // unreachable, helps TS
+  }
+
+  if (outputJson && checkOnly) {
+    out(result);
+    return;
+  }
+
+  if (!result.updateAvailable) {
+    if (outputJson) {
+      out(result);
+    } else {
+      success(`Already up to date (v${result.current})`);
+    }
+    return;
+  }
+
+  // Update is available
+  if (checkOnly) {
+    if (outputJson) {
+      out(result);
+    } else {
+      outputWrite(`${c.yellow}Update available:${c.reset} v${result.current} → v${c.green}${result.latest}${c.reset}`);
+      outputWrite(`Run ${c.dim}memoclaw upgrade${c.reset} to install.`);
+    }
+    return;
+  }
+
+  // Prompt or auto-install
+  if (!autoYes && process.stdin.isTTY) {
+    outputWrite(`${c.yellow}Update available:${c.reset} v${result.current} → v${c.green}${result.latest}${c.reset}`);
+    process.stdout.write(`Install now? [Y/n] `);
+
+    const answer = await new Promise<string>((resolve) => {
+      let data = '';
+      process.stdin.setEncoding('utf-8');
+      process.stdin.once('data', (chunk) => {
+        data = chunk.toString().trim();
+        resolve(data);
+      });
+      // Handle Ctrl+C / EOF
+      process.stdin.once('end', () => resolve('n'));
+    });
+
+    if (answer.toLowerCase() === 'n') {
+      info('Upgrade cancelled.');
+      return;
+    }
+  } else if (!autoYes) {
+    // Non-interactive, no --yes flag
+    if (outputJson) {
+      out({ ...result, message: 'Update available. Run with --yes to auto-install.' });
+    } else {
+      outputWrite(`${c.yellow}Update available:${c.reset} v${result.current} → v${c.green}${result.latest}${c.reset}`);
+      outputWrite(`Run ${c.dim}memoclaw upgrade --yes${c.reset} to install non-interactively.`);
+    }
+    return;
+  }
+
+  // Do the install
+  if (!outputJson) {
+    outputWrite(`${c.dim}Installing memoclaw@${result.latest}...${c.reset}`);
+  }
+
+  const installResult = installUpdate();
+
+  if (installResult.success) {
+    if (outputJson) {
+      out({ ...result, installed: true, message: `Updated to v${result.latest}` });
+    } else {
+      success(`Updated to v${result.latest}`);
+    }
+  } else {
+    if (outputJson) {
+      out({ ...result, installed: false, error: installResult.output });
+    } else {
+      outputWrite(`${c.red}Error:${c.reset} Failed to install update.`);
+      outputWrite(`${c.dim}${installResult.output}${c.reset}`);
+      outputWrite(`\nTry manually: ${c.cyan}npm install -g memoclaw@latest${c.reset}`);
+    }
+    process.exit(1);
+  }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -383,6 +383,19 @@ Print your wallet address. Useful for scripting.
   ${c.dim}WALLET=$(memoclaw whoami)${c.reset}
   ${c.dim}memoclaw whoami --json${c.reset}`,
 
+      upgrade: `${c.bold}memoclaw upgrade${c.reset} [options]
+
+Check for and install CLI updates from npm.
+
+  ${c.dim}memoclaw upgrade${c.reset}              Check and prompt to install
+  ${c.dim}memoclaw upgrade --yes${c.reset}         Auto-install without prompting
+  ${c.dim}memoclaw upgrade --check${c.reset}       Check only, don't install
+
+Options:
+  --check                Just check for updates (don't install)
+  --yes, -y              Auto-install without prompting
+  --json                 Machine-readable output`,
+
       namespace: `${c.bold}memoclaw namespace${c.reset} [list|stats]
 
 Manage and view namespaces.
@@ -440,6 +453,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}purge${c.reset}                  Delete ALL memories (requires --force or confirm)
   ${c.cyan}namespace${c.reset} [list|stats] Manage and view namespaces
   ${c.cyan}count${c.reset}                  Quick memory count
+  ${c.cyan}upgrade${c.reset}                Check for and install CLI updates
   ${c.cyan}help${c.reset} [command]          Show help for a command
 
 ${c.bold}Global Options:${c.reset}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -309,10 +309,10 @@ describe('export format', () => {
 describe('completions', () => {
   const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
-    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'whoami', 'help'];
+    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'whoami', 'upgrade', 'help'];
 
   test('all commands present', () => {
-    expect(commands.length).toBe(31);
+    expect(commands.length).toBe(32);
     expect(commands).toContain('store');
     expect(commands).toContain('get');
     expect(commands).toContain('bulk-delete');

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect } from 'bun:test';
+import { compareSemver, type VersionCheckResult } from '../src/commands/upgrade';
+import { parseArgs, BOOLEAN_FLAGS } from '../src/args';
+
+// ─── Version comparison ─────────────────────────────────────────────────────
+
+describe('compareSemver', () => {
+  test('equal versions return 0', () => {
+    expect(compareSemver('1.9.0', '1.9.0')).toBe(0);
+    expect(compareSemver('0.0.0', '0.0.0')).toBe(0);
+    expect(compareSemver('10.20.30', '10.20.30')).toBe(0);
+  });
+
+  test('older major returns -1', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1);
+    expect(compareSemver('0.9.9', '1.0.0')).toBe(-1);
+  });
+
+  test('newer major returns 1', () => {
+    expect(compareSemver('2.0.0', '1.0.0')).toBe(1);
+    expect(compareSemver('10.0.0', '9.99.99')).toBe(1);
+  });
+
+  test('older minor returns -1', () => {
+    expect(compareSemver('1.8.0', '1.9.0')).toBe(-1);
+    expect(compareSemver('1.0.0', '1.1.0')).toBe(-1);
+  });
+
+  test('newer minor returns 1', () => {
+    expect(compareSemver('1.9.0', '1.8.0')).toBe(1);
+  });
+
+  test('older patch returns -1', () => {
+    expect(compareSemver('1.9.0', '1.9.1')).toBe(-1);
+    expect(compareSemver('1.0.0', '1.0.99')).toBe(-1);
+  });
+
+  test('newer patch returns 1', () => {
+    expect(compareSemver('1.9.1', '1.9.0')).toBe(1);
+  });
+
+  test('handles partial versions', () => {
+    // Missing components default to 0
+    expect(compareSemver('1', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0', '1.0.0')).toBe(0);
+  });
+});
+
+// ─── VersionCheckResult ──────────────────────────────────────────────────────
+
+describe('VersionCheckResult', () => {
+  test('updateAvailable is true when latest > current', () => {
+    const result: VersionCheckResult = {
+      current: '1.8.0',
+      latest: '1.9.0',
+      updateAvailable: compareSemver('1.8.0', '1.9.0') < 0,
+    };
+    expect(result.updateAvailable).toBe(true);
+  });
+
+  test('updateAvailable is false when equal', () => {
+    const result: VersionCheckResult = {
+      current: '1.9.0',
+      latest: '1.9.0',
+      updateAvailable: compareSemver('1.9.0', '1.9.0') < 0,
+    };
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  test('updateAvailable is false when current > latest', () => {
+    const result: VersionCheckResult = {
+      current: '2.0.0',
+      latest: '1.9.0',
+      updateAvailable: compareSemver('2.0.0', '1.9.0') < 0,
+    };
+    expect(result.updateAvailable).toBe(false);
+  });
+});
+
+// ─── CLI args for upgrade ────────────────────────────────────────────────────
+
+describe('upgrade CLI args', () => {
+  test('upgrade command is parsed as positional', () => {
+    const result = parseArgs(['upgrade']);
+    expect(result._).toEqual(['upgrade']);
+  });
+
+  test('upgrade --check flag', () => {
+    const result = parseArgs(['upgrade', '--check']);
+    expect(result._).toEqual(['upgrade']);
+    expect(result.check).toBe(true);
+  });
+
+  test('upgrade --yes flag', () => {
+    const result = parseArgs(['upgrade', '--yes']);
+    expect(result._).toEqual(['upgrade']);
+    expect(result.yes).toBe(true);
+  });
+
+  test('upgrade -y short flag', () => {
+    const result = parseArgs(['upgrade', '-y']);
+    expect(result._).toEqual(['upgrade']);
+    expect(result.yes).toBe(true);
+  });
+
+  test('upgrade --json flag', () => {
+    const result = parseArgs(['upgrade', '--json']);
+    expect(result._).toEqual(['upgrade']);
+    expect(result.json).toBe(true);
+  });
+
+  test('check is a boolean flag', () => {
+    expect(BOOLEAN_FLAGS.has('check')).toBe(true);
+  });
+
+  test('upgrade --check --json', () => {
+    const result = parseArgs(['upgrade', '--check', '--json']);
+    expect(result.check).toBe(true);
+    expect(result.json).toBe(true);
+  });
+});
+
+// ─── Completions include upgrade ─────────────────────────────────────────────
+
+describe('completions include upgrade', () => {
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
+    'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
+    'completions', 'config', 'graph', 'history', 'purge', 'count', 'namespace', 'whoami', 'upgrade', 'help'];
+
+  test('upgrade is in commands list', () => {
+    expect(commands).toContain('upgrade');
+  });
+
+  test('total command count is 32', () => {
+    expect(commands.length).toBe(32);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `memoclaw upgrade` command that checks npm for the latest version and offers to install it.

## Changes
- **`src/commands/upgrade.ts`**: New command with npm registry check, semver comparison, version caching, and install logic
- **`src/cli.ts`**: Wire upgrade command into router
- **`src/help.ts`**: Help text for upgrade command + added to main help listing
- **`src/args.ts`**: Register `check` as boolean flag
- **`src/commands/completions.ts`**: Add upgrade to shell completions
- **`test/upgrade.test.ts`**: Tests for semver comparison, version check result, CLI arg parsing

## Usage
```bash
memoclaw upgrade              # Check and prompt to install
memoclaw upgrade --yes        # Auto-install without prompting  
memoclaw upgrade --check      # Just check, don't install
memoclaw upgrade --json       # Machine-readable output
```

## Implementation Details
- Fetches `https://registry.npmjs.org/memoclaw/latest` for version info
- Caches check result at `~/.memoclaw/last-version-check.json` (1h TTL)
- Uses `npm install -g memoclaw@latest` for installation
- Interactive Y/n prompt in TTY mode, non-interactive mode shows instructions
- JSON output support for all modes

Fixes #117