### PR TITLE
feat: add pin/unpin shorthand commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { printHelp } from './help.js';
 import { cmdStore, cmdStoreBatch, readFileContent } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
-import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } from './commands/memory.js';
+import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin } from './commands/memory.js';
 
 import { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } from './commands/search.js';
 import { cmdRelations } from './commands/relations.js';
@@ -132,6 +132,14 @@ try {
     case 'delete':
       if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw delete <id>');
       await cmdDelete(rest[0]);
+      break;
+    case 'pin':
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw pin <id>');
+      await cmdPin(rest[0], args);
+      break;
+    case 'unpin':
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw unpin <id>');
+      await cmdUnpin(rest[0], args);
       break;
     case 'bulk-delete': {
       let ids = rest;

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,5 +1,5 @@
 export async function cmdCompletions(shell: string) {
-  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'ingest', 'extract',
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'pin', 'unpin', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'tags', 'namespace', 'whoami', 'upgrade', 'help'];
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -105,3 +105,21 @@ export async function cmdUpdate(id: string, opts: ParsedArgs) {
     success(`Memory ${c.cyan}${id.slice(0, 8)}…${c.reset} updated`);
   }
 }
+
+export async function cmdPin(id: string, opts?: ParsedArgs) {
+  const result = await request('PATCH', `/v1/memories/${id}`, { pinned: true });
+  if (outputJson) {
+    out(result);
+  } else {
+    success(`Memory ${c.cyan}${id.slice(0, 8)}…${c.reset} pinned`);
+  }
+}
+
+export async function cmdUnpin(id: string, opts?: ParsedArgs) {
+  const result = await request('PATCH', `/v1/memories/${id}`, { pinned: false });
+  if (outputJson) {
+    out(result);
+  } else {
+    success(`Memory ${c.cyan}${id.slice(0, 8)}…${c.reset} unpinned`);
+  }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -192,6 +192,20 @@ Delete a memory by ID.
 
   ${c.dim}memoclaw delete abc123${c.reset}`,
 
+      pin: `${c.bold}memoclaw pin${c.reset} <id>
+
+Pin a memory. Shorthand for: memoclaw update <id> --pinned true
+
+  ${c.dim}memoclaw pin abc123${c.reset}
+  ${c.dim}memoclaw pin abc123 --json${c.reset}`,
+
+      unpin: `${c.bold}memoclaw unpin${c.reset} <id>
+
+Unpin a memory. Shorthand for: memoclaw update <id> --pinned false
+
+  ${c.dim}memoclaw unpin abc123${c.reset}
+  ${c.dim}memoclaw unpin abc123 --json${c.reset}`,
+
       'bulk-delete': `${c.bold}memoclaw bulk-delete${c.reset} <id1> <id2> ...
 
 Delete multiple memories at once. IDs can be provided as arguments
@@ -451,6 +465,8 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}update${c.reset} <id>            Update a memory
   ${c.cyan}delete${c.reset} <id>            Delete a memory
   ${c.cyan}bulk-delete${c.reset} <ids>       Delete multiple memories at once
+  ${c.cyan}pin${c.reset} <id>              Pin a memory
+  ${c.cyan}unpin${c.reset} <id>            Unpin a memory
   ${c.cyan}ingest${c.reset}                 Ingest raw text into memories
   ${c.cyan}extract${c.reset} "text"         Extract memories from text
   ${c.cyan}context${c.reset} "query"        Get GPT-powered contextual summary ($0.01/call)

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -101,7 +101,7 @@ function resetOutputState(overrides: Record<string, any> = {}) {
 const { cmdStore, cmdStoreBatch } = await import('../src/commands/store.js');
 const { cmdRecall } = await import('../src/commands/recall.js');
 const { cmdList } = await import('../src/commands/list.js');
-const { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete } = await import('../src/commands/memory.js');
+const { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin } = await import('../src/commands/memory.js');
 const { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } = await import('../src/commands/search.js');
 const { cmdCount, cmdSuggested, cmdGraph } = await import('../src/commands/status.js');
 const { cmdHistory } = await import('../src/commands/history.js');
@@ -2374,5 +2374,75 @@ describe('cmdTags', () => {
     const output = consoleOutput.join('\n');
     expect(output).toContain('tag');
     expect(output).toContain('csv-tag');
+  });
+});
+
+// ─── #125: pin / unpin commands ──────────────────────────────────────────────
+
+describe('cmdPin', () => {
+  test('sends PATCH with pinned=true', async () => {
+    mockFetchResponse = { id: 'abc-12345678' };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdPin('abc-12345678');
+    restoreConsole();
+    expect(lastFetchOptions.method).toBe('PATCH');
+    expect(lastFetchUrl).toContain('/v1/memories/abc-12345678');
+    expect(getLastBody()).toEqual({ pinned: true });
+  });
+
+  test('shows success message with truncated ID', async () => {
+    mockFetchResponse = { id: 'abc-12345678' };
+    captureConsole();
+    await cmdPin('abc-12345678');
+    restoreConsole();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('pinned');
+    expect(output).toContain('abc-1234');
+  });
+
+  test('JSON mode outputs raw response', async () => {
+    mockFetchResponse = { id: 'abc-12345678', pinned: true };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdPin('abc-12345678');
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.pinned).toBe(true);
+  });
+});
+
+describe('cmdUnpin', () => {
+  test('sends PATCH with pinned=false', async () => {
+    mockFetchResponse = { id: 'abc-12345678' };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdUnpin('abc-12345678');
+    restoreConsole();
+    expect(lastFetchOptions.method).toBe('PATCH');
+    expect(lastFetchUrl).toContain('/v1/memories/abc-12345678');
+    expect(getLastBody()).toEqual({ pinned: false });
+  });
+
+  test('shows success message with truncated ID', async () => {
+    mockFetchResponse = { id: 'abc-12345678' };
+    captureConsole();
+    await cmdUnpin('abc-12345678');
+    restoreConsole();
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('unpinned');
+    expect(output).toContain('abc-1234');
+  });
+
+  test('JSON mode outputs raw response', async () => {
+    mockFetchResponse = { id: 'abc-12345678', pinned: false };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdUnpin('abc-12345678');
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.pinned).toBe(false);
   });
 });

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -8,8 +8,8 @@ describe('printHelp', () => {
 
   const commands = [
     'store', 'recall', 'list', 'search', 'context', 'get', 'update', 'delete',
-    'ingest', 'extract', 'consolidate', 'relations', 'suggested', 'export',
-    'import', 'stats', 'config', 'browse', 'graph', 'purge', 'count',
+    'pin', 'unpin', 'ingest', 'extract', 'consolidate', 'relations', 'suggested',
+    'export', 'import', 'stats', 'config', 'browse', 'graph', 'purge', 'count',
     'completions', 'history', 'tags', 'namespace', 'init', 'migrate',
   ];
 


### PR DESCRIPTION
## Summary

Adds `memoclaw pin <id>` and `memoclaw unpin <id>` as convenience shorthands for the verbose `memoclaw update <id> --pinned true/false`.

## Changes

- **`src/commands/memory.ts`**: Added `cmdPin` and `cmdUnpin` functions (thin wrappers around PATCH with `{ pinned: true/false }`)
- **`src/cli.ts`**: Wired `pin` and `unpin` switch cases
- **`src/help.ts`**: Added help text for both commands + listed in overview
- **`src/commands/completions.ts`**: Added to shell completion command lists
- **`test/commands.test.ts`**: 6 tests covering both commands (PATCH body, success messages, JSON mode)
- **`test/help.test.ts`**: Added pin/unpin to help smoke tests

## Acceptance Criteria

- [x] `memoclaw pin <id>` sets pinned=true
- [x] `memoclaw unpin <id>` sets pinned=false
- [x] Supports `--json` output
- [x] Help text added for both commands
- [x] Shell completions updated
- [x] Tests added (6 new tests, all 512 pass)

Fixes #125