### PR TITLE
fix: export CSV/TSV date filters, --no-color flag, add copy & move commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@
 
 import { parseArgs } from './args.js';
 import { VERSION, DEFAULT_NAMESPACE, DEFAULT_TIMEOUT } from './config.js';
-import { c } from './colors.js';
+import { c, disableColors } from './colors.js';
 import { configureOutput, outputJson, readStdin } from './output.js';
 import { setRequestTimeout, setMaxRetries } from './http.js';
 import { printHelp } from './help.js';
@@ -22,7 +22,7 @@ import { printHelp } from './help.js';
 import { cmdStore, cmdStoreBatch, readFileContent } from './commands/store.js';
 import { cmdRecall } from './commands/recall.js';
 import { cmdList } from './commands/list.js';
-import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin, cmdLock, cmdUnlock, cmdEdit } from './commands/memory.js';
+import { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin, cmdLock, cmdUnlock, cmdEdit, cmdCopy, cmdMove } from './commands/memory.js';
 
 import { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } from './commands/search.js';
 import { cmdRelations } from './commands/relations.js';
@@ -45,6 +45,11 @@ import { cmdWatch } from './commands/watch.js';
 
 const args = parseArgs(process.argv.slice(2));
 const [cmd, ...rest] = args._;
+
+// Disable colors if --no-color flag is passed
+if (args.noColor) {
+  disableColors();
+}
 
 // Configure output state
 configureOutput(args);
@@ -157,6 +162,20 @@ try {
     case 'watch':
       await cmdWatch(args);
       break;
+    case 'copy':
+      if (!rest[0]) throw new Error('Memory ID required. Usage: memoclaw copy <id> [--namespace <ns>]');
+      await cmdCopy(rest[0], args);
+      break;
+    case 'move': {
+      let ids = rest;
+      if (ids.length === 0) {
+        const stdin = await readStdin();
+        if (stdin) ids = stdin.split(/[\n,\s]+/).map(s => s.trim()).filter(Boolean);
+      }
+      if (ids.length === 0) throw new Error('Memory ID(s) required. Usage: memoclaw move <id> --namespace <target>');
+      await cmdMove(ids, args);
+      break;
+    }
     case 'bulk-delete': {
       let ids = rest;
       if (ids.length === 0) {

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -2,9 +2,24 @@
  * Terminal color utilities
  */
 
-const NO_COLOR = !!process.env.NO_COLOR || !process.stdout.isTTY;
+let NO_COLOR = !!process.env.NO_COLOR || !process.stdout.isTTY;
 
-export const c = {
+/** Disable all color output (called after arg parsing when --no-color is used) */
+export function disableColors() {
+  NO_COLOR = true;
+  c.reset = '';
+  c.bold = '';
+  c.dim = '';
+  c.red = '';
+  c.green = '';
+  c.yellow = '';
+  c.blue = '';
+  c.magenta = '';
+  c.cyan = '';
+  c.gray = '';
+}
+
+export const c: Record<string, string> = {
   reset: NO_COLOR ? '' : '\x1b[0m',
   bold: NO_COLOR ? '' : '\x1b[1m',
   dim: NO_COLOR ? '' : '\x1b[2m',

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,5 +1,5 @@
 export async function cmdCompletions(shell: string) {
-  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'pin', 'unpin', 'lock', 'unlock', 'edit', 'watch', 'ingest', 'extract',
+  const commands = ['init', 'migrate', 'store', 'recall', 'search', 'list', 'get', 'update', 'delete', 'bulk-delete', 'pin', 'unpin', 'lock', 'unlock', 'edit', 'watch', 'copy', 'move', 'ingest', 'extract',
     'context', 'consolidate', 'relations', 'core', 'suggested', 'status', 'export', 'import', 'stats', 'browse',
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'tags', 'namespace', 'whoami', 'upgrade', 'help'];
 

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -48,10 +48,10 @@ export async function cmdExport(opts: ParsedArgs) {
     outputWrite(JSON.stringify(exportData, null, 2));
   } else if (outputFormat === 'csv' || outputFormat === 'tsv') {
     const sep = outputFormat === 'tsv' ? '\t' : ',';
-    if (allMemories.length > 0) {
+    if (filteredMemories.length > 0) {
       const headers = ['id', 'content', 'importance', 'namespace', 'tags', 'created_at'];
       outputWrite(headers.join(sep));
-      for (const m of allMemories) {
+      for (const m of filteredMemories) {
         const row = [
           m.id || '',
           m.content || '',

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,12 +1,12 @@
 /**
- * Single-memory commands: get, delete, update
+ * Single-memory commands: get, delete, update, copy, move
  */
 
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, out, outputWrite, success, readStdin } from '../output.js';
-import { MAX_CONTENT_LENGTH, validateContentLength, validateImportance, warnIfBooleanImportance } from '../validate.js';
+import { validateContentLength, validateImportance, warnIfBooleanImportance } from '../validate.js';
 import { readFileContent } from './store.js';
 
 export async function cmdGet(id: string, opts?: ParsedArgs) {
@@ -197,5 +197,58 @@ export async function cmdEdit(id: string, opts?: ParsedArgs) {
   } finally {
     // Clean up temp file
     try { unlinkSync(tmpFile); } catch {}
+  }
+}
+
+export async function cmdCopy(id: string, opts: ParsedArgs) {
+  // Fetch the source memory
+  const result = await request('GET', `/v1/memories/${id}`) as any;
+  const mem = result.memory || result;
+
+  // Build the new memory body, preserving original fields
+  const body: Record<string, any> = { content: mem.content };
+  if (mem.importance !== undefined) body.importance = mem.importance;
+  if (mem.metadata?.tags?.length) body.metadata = { tags: [...mem.metadata.tags] };
+  if (mem.memory_type) body.memory_type = mem.memory_type;
+  if (mem.session_id) body.session_id = mem.session_id;
+  if (mem.agent_id) body.agent_id = mem.agent_id;
+
+  // Use source namespace unless overridden
+  body.namespace = opts.namespace || mem.namespace;
+
+  // Apply overrides from flags
+  if (opts.importance != null && !warnIfBooleanImportance(opts.importance)) {
+    body.importance = validateImportance(opts.importance);
+  }
+  if (opts.tags) {
+    const newTags = opts.tags.split(',').map((t: string) => t.trim());
+    body.metadata = { tags: newTags };
+  }
+  if (opts.memoryType) body.memory_type = opts.memoryType;
+  // Deliberately do NOT copy immutable flag — new memory should be mutable
+
+  const storeResult = await request('POST', '/v1/store', body) as any;
+  if (outputJson) {
+    out({ source: id, id: storeResult.id, copied: true });
+  } else {
+    success(`Copied ${c.cyan}${id.slice(0, 8)}…${c.reset} → ${c.cyan}${(storeResult.id || '?').slice(0, 8)}…${c.reset}`);
+  }
+}
+
+export async function cmdMove(ids: string[], opts: ParsedArgs) {
+  if (!opts.namespace) {
+    throw new Error('Target namespace required. Usage: memoclaw move <id> --namespace <target>');
+  }
+
+  let moved = 0;
+  for (const id of ids) {
+    await request('PATCH', `/v1/memories/${id}`, { namespace: opts.namespace });
+    moved++;
+  }
+
+  if (outputJson) {
+    out({ moved, namespace: opts.namespace, ids });
+  } else {
+    success(`Moved ${c.cyan}${moved}${c.reset} memor${moved === 1 ? 'y' : 'ies'} to namespace ${c.cyan}${opts.namespace}${c.reset}`);
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -254,6 +254,33 @@ Options:
   --interval <seconds>   Poll interval (default: 3)
   --json                 Output JSON lines (for piping)`,
 
+      copy: `${c.bold}memoclaw copy${c.reset} <id> [options]
+
+Duplicate an existing memory. The new memory gets a fresh ID and is mutable
+by default, even if the source was immutable.
+
+  ${c.dim}memoclaw copy abc123${c.reset}
+  ${c.dim}memoclaw copy abc123 --namespace other-project${c.reset}
+  ${c.dim}memoclaw copy abc123 --importance 0.9 --tags new-tag${c.reset}
+
+Options:
+  --namespace <name>     Target namespace (default: same as source)
+  --importance <0-1>     Override importance score
+  --tags <tag1,tag2>     Override tags
+  --memory-type <type>   Override memory type`,
+
+      move: `${c.bold}memoclaw move${c.reset} <id> [<id2> ...] --namespace <target>
+
+Move one or more memories to a different namespace.
+IDs can be provided as arguments or piped via stdin.
+
+  ${c.dim}memoclaw move abc123 --namespace production${c.reset}
+  ${c.dim}memoclaw move abc123 def456 --namespace archive${c.reset}
+  ${c.dim}memoclaw list --namespace staging --json | jq -r '.memories[].id' | memoclaw move --namespace production${c.reset}
+
+Options:
+  --namespace <name>     Target namespace (required)`,
+
       'bulk-delete': `${c.bold}memoclaw bulk-delete${c.reset} <id1> <id2> ...
 
 Delete multiple memories at once. IDs can be provided as arguments
@@ -519,6 +546,8 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}unlock${c.reset} <id>           Unlock a memory (make mutable)
   ${c.cyan}edit${c.reset} <id>             Edit a memory in $EDITOR
   ${c.cyan}watch${c.reset}                  Watch for new memories in real-time
+  ${c.cyan}copy${c.reset} <id>             Duplicate a memory
+  ${c.cyan}move${c.reset} <id> --namespace  Move memory to another namespace
   ${c.cyan}ingest${c.reset}                 Ingest raw text into memories
   ${c.cyan}extract${c.reset} "text"         Extract memories from text
   ${c.cyan}context${c.reset} "query"        Get GPT-powered contextual summary ($0.01/call)

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { c } from '../src/colors';
+import { c, disableColors } from '../src/colors';
 
 describe('colors', () => {
   const colorKeys = ['reset', 'bold', 'dim', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'gray'];
@@ -22,6 +22,13 @@ describe('colors', () => {
     for (const key of colorKeys) {
       const val = (c as any)[key];
       expect(val === '' || val.startsWith('\x1b[')).toBe(true);
+    }
+  });
+
+  test('disableColors() sets all color values to empty strings', () => {
+    disableColors();
+    for (const key of colorKeys) {
+      expect((c as any)[key]).toBe('');
     }
   });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -101,7 +101,7 @@ function resetOutputState(overrides: Record<string, any> = {}) {
 const { cmdStore, cmdStoreBatch } = await import('../src/commands/store.js');
 const { cmdRecall } = await import('../src/commands/recall.js');
 const { cmdList } = await import('../src/commands/list.js');
-const { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin, cmdLock, cmdUnlock, cmdEdit } = await import('../src/commands/memory.js');
+const { cmdGet, cmdDelete, cmdUpdate, cmdBulkDelete, cmdPin, cmdUnpin, cmdLock, cmdUnlock, cmdEdit, cmdCopy, cmdMove } = await import('../src/commands/memory.js');
 const { cmdSearch, cmdContext, cmdExtract, cmdIngest, cmdConsolidate } = await import('../src/commands/search.js');
 const { cmdCount, cmdSuggested, cmdGraph } = await import('../src/commands/status.js');
 const { cmdHistory } = await import('../src/commands/history.js');
@@ -2563,5 +2563,99 @@ describe('cmdWatch', () => {
   test('module exports cmdWatch', async () => {
     const mod = await import('../src/commands/watch.js');
     expect(typeof mod.cmdWatch).toBe('function');
+  });
+});
+
+// ─── #133: export CSV/TSV date filter fix ────────────────────────────────────
+
+describe('export CSV respects --since filter', () => {
+  const now = Date.now();
+  const recentDate = new Date(now - 1000 * 60 * 60).toISOString(); // 1h ago
+  const oldDate = new Date(now - 1000 * 60 * 60 * 24 * 30).toISOString(); // 30d ago
+
+  test('CSV export only includes filtered memories with --since', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'recent-csv', content: 'recent', created_at: recentDate, importance: 0.5, namespace: '', metadata: {} },
+        { id: 'old-csv', content: 'old', created_at: oldDate, importance: 0.3, namespace: '', metadata: {} },
+      ],
+      total: 2,
+    };
+    resetOutputState({ format: 'csv' });
+    captureConsole();
+    await cmdExport({ _: ['export'], since: '7d', format: 'csv' } as any);
+    restoreConsole();
+    resetOutputState();
+    // CSV output: first line is headers, rest are data rows
+    const lines = consoleOutput.filter(l => l.trim());
+    const dataLines = lines.filter(l => !l.startsWith('id,') && !l.includes('✓'));
+    expect(dataLines.length).toBe(1);
+    expect(dataLines[0]).toContain('recent-csv');
+    expect(dataLines.join('')).not.toContain('old-csv');
+  });
+});
+
+// ─── #135: copy command ──────────────────────────────────────────────────────
+
+describe('cmdCopy', () => {
+  test('duplicates a memory and returns new ID', async () => {
+    let callCount = 0;
+    mockFetchResponse = (url: string, init: any) => {
+      callCount++;
+      if (callCount === 1) {
+        // GET /v1/memories/:id
+        return { memory: { id: 'source-id', content: 'hello', importance: 0.8, namespace: 'ns1', metadata: { tags: ['a'] } } };
+      }
+      // POST /v1/store
+      return { id: 'new-copy-id' };
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdCopy('source-id', { _: ['copy'] } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.source).toBe('source-id');
+    expect(parsed.id).toBe('new-copy-id');
+    expect(parsed.copied).toBe(true);
+  });
+
+  test('copy with namespace override', async () => {
+    let storeBody: any = null;
+    let callCount = 0;
+    mockFetchResponse = (url: string, init: any) => {
+      callCount++;
+      if (callCount === 1) {
+        return { memory: { id: 'src', content: 'data', namespace: 'old-ns' } };
+      }
+      storeBody = JSON.parse(init?.body || '{}');
+      return { id: 'new-id' };
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdCopy('src', { _: ['copy'], namespace: 'new-ns' } as any);
+    restoreConsole();
+    resetOutputState();
+    expect(storeBody.namespace).toBe('new-ns');
+  });
+});
+
+// ─── #136: move command ──────────────────────────────────────────────────────
+
+describe('cmdMove', () => {
+  test('moves memories to target namespace', async () => {
+    mockFetchResponse = { updated: true };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove(['id1', 'id2'], { _: ['move'], namespace: 'production' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(2);
+    expect(parsed.namespace).toBe('production');
+  });
+
+  test('throws if no namespace provided', async () => {
+    expect(() => cmdMove(['id1'], { _: ['move'] } as any)).toThrow('Target namespace required');
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes 2 bugs and adds 2 new commands.

### Bug Fixes

- **Fixes #133**: `export --format csv --since 7d` was exporting ALL memories instead of only filtered ones. The CSV/TSV branch used `allMemories` instead of `filteredMemories`.
- **Fixes #134**: `--no-color` CLI flag was defined in args but never wired to the color system. Added `disableColors()` to the colors module, called after arg parsing.

### New Commands

- **Fixes #135**: `memoclaw copy <id>` — Duplicates a memory with optional overrides (`--namespace`, `--importance`, `--tags`, `--memory-type`). Deliberately does NOT copy the immutable flag.
- **Fixes #136**: `memoclaw move <id> --namespace <target>` — Moves memory(ies) to a different namespace. Accepts multiple IDs as args or piped via stdin.

### Also Updated
- Shell completions (bash/zsh/fish) include `copy` and `move`
- Help text for both new commands
- Main help listing updated
- Tests for all changes (export CSV filter fix, copy, move, disableColors)

### Test Results
```
518 pass, 0 fail
886 expect() calls
```