### PR TITLE
fix: over-fetch when date filters active (Fixes #140)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,7 +2,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, outputTruncate, noTruncate, out, table, outputWrite } from '../output.js';
-import { parseDate, filterByDateRange } from '../dates.js';
+import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
 
 /** Apply client-side sorting to memories array */
 function sortMemories(memories: any[], opts: ParsedArgs): any[] {
@@ -132,6 +132,17 @@ export async function cmdList(opts: ParsedArgs) {
     );
   }
 
+  // Over-fetch when date filters are active so client-side filtering
+  // doesn't leave the user with fewer results than requested (#140)
+  const hasDateFilter = !!(sinceDate || untilDate);
+  const userLimit = opts.limit != null && opts.limit !== true ? parseInt(opts.limit) : undefined;
+  if (hasDateFilter) {
+    params.set('limit', String(overfetchLimit(userLimit)));
+    // Pass dates to server too (best-effort, server may ignore)
+    if (sinceDate) params.set('since', sinceDate.toISOString());
+    if (untilDate) params.set('until', untilDate.toISOString());
+  }
+
   // Watch mode
   if (opts.watch) {
     let lastFingerprint = '';
@@ -183,10 +194,12 @@ export async function cmdList(opts: ParsedArgs) {
   }
 
   const result = await request('GET', `/v1/memories?${params}`) as any;
+  const trimLimit = hasDateFilter && userLimit ? userLimit : undefined;
 
   if (outputJson) {
-    if (sinceDate || untilDate) {
-      const filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
+    if (hasDateFilter) {
+      let filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
+      if (trimLimit) filtered = filtered.slice(0, trimLimit);
       out({ ...result, memories: filtered, total: filtered.length });
     } else {
       out(result);
@@ -194,12 +207,14 @@ export async function cmdList(opts: ParsedArgs) {
   } else if (opts.raw) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     for (const mem of memories) {
       outputWrite(mem.content || '');
     }
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     memories = sortMemories(memories, opts);
     const rows = memories.map((m: any) => ({
       id: m.id || '',
@@ -213,8 +228,9 @@ export async function cmdList(opts: ParsedArgs) {
   } else {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     memories = sortMemories(memories, opts);
     const columns = buildColumns(opts);
-    renderTable(memories, columns, opts, sinceDate || untilDate ? memories.length : result.total);
+    renderTable(memories, columns, opts, hasDateFilter ? memories.length : result.total);
   }
 }

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -2,7 +2,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputTruncate, outputFormat, out, outputWrite, truncate } from '../output.js';
-import { parseDate, filterByDateRange } from '../dates.js';
+import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
 
 /** Render a list of recall memories to stdout (shared between normal and watch mode) */
 function renderMemories(memories: any[], opts: { showId?: boolean } = {}) {
@@ -40,6 +40,16 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
       `Invalid date format. Use ISO 8601 (2025-01-01) or relative shorthand (1h, 7d, 2w, 1mo, 1y).`
     );
   }
+
+  // Over-fetch when date filters are active (#140)
+  const hasDateFilter = !!(sinceDate || untilDate);
+  const userLimit = body.limit;
+  if (hasDateFilter) {
+    body.limit = overfetchLimit(userLimit);
+    if (sinceDate) body.since = sinceDate.toISOString();
+    if (untilDate) body.until = untilDate.toISOString();
+  }
+  const trimLimit = hasDateFilter && userLimit ? userLimit : undefined;
 
   // Watch mode
   if (opts.watch) {
@@ -90,8 +100,9 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   const result = await request('POST', '/v1/recall', body) as any;
 
   if (outputJson) {
-    if (sinceDate || untilDate) {
-      const filtered = filterByDateRange(result.memories || [], 'created_at', sinceDate, untilDate);
+    if (hasDateFilter) {
+      let filtered = filterByDateRange(result.memories || [], 'created_at', sinceDate, untilDate);
+      if (trimLimit) filtered = filtered.slice(0, trimLimit);
       out({ ...result, memories: filtered });
     } else {
       out(result);
@@ -99,6 +110,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     const rows = memories.map((m: any) => ({
       id: m.id || '',
       similarity: m.similarity?.toFixed(3) || '',
@@ -110,12 +122,14 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     for (const mem of memories) {
       outputWrite(mem.content);
     }
   } else {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     renderMemories(memories, { showId: true });
   }
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -7,7 +7,7 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, truncate, table, readStdin } from '../output.js';
 import { validateContentLength, validateBulkContentLength } from '../validate.js';
-import { parseDate, filterByDateRange } from '../dates.js';
+import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -24,11 +24,22 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     );
   }
 
+  // Over-fetch when date filters are active (#140)
+  const hasDateFilter = !!(sinceDate || untilDate);
+  const userLimit = opts.limit != null && opts.limit !== true ? parseInt(opts.limit) : undefined;
+  if (hasDateFilter) {
+    params.set('limit', String(overfetchLimit(userLimit)));
+    if (sinceDate) params.set('since', sinceDate.toISOString());
+    if (untilDate) params.set('until', untilDate.toISOString());
+  }
+  const trimLimit = hasDateFilter && userLimit ? userLimit : undefined;
+
   const result = await request('GET', `/v1/memories/search?${params}`) as any;
 
   if (outputJson) {
-    if (sinceDate || untilDate) {
-      const filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
+    if (hasDateFilter) {
+      let filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
+      if (trimLimit) filtered = filtered.slice(0, trimLimit);
       out({ ...result, memories: filtered });
     } else {
       out(result);
@@ -36,12 +47,14 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     for (const mem of memories) {
       outputWrite(mem.content);
     }
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     const rows = memories.map((m: any) => ({
       id: m.id || '',
       content: m.content || '',
@@ -51,6 +64,7 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
   } else {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    if (trimLimit) memories = memories.slice(0, trimLimit);
     if (memories.length === 0) {
       outputWrite(`${c.dim}No memories found.${c.reset}`);
     } else {

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -47,6 +47,16 @@ export function parseDate(input: string): Date | null {
 }
 
 /**
+ * Compute an over-fetch limit when client-side date filtering is active.
+ * Fetches 3x the requested limit (min 100, max 1000) to compensate for
+ * records that will be removed by date filtering.
+ */
+export function overfetchLimit(requestedLimit: number | undefined): number {
+  const base = requestedLimit ?? 20;
+  return Math.min(Math.max(base * 3, 100), 1000);
+}
+
+/**
  * Filter an array of objects by date range.
  * @param items - Array of objects
  * @param dateKey - Key containing the date string (e.g. 'created_at')

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -2566,6 +2566,66 @@ describe('cmdWatch', () => {
   });
 });
 
+// ─── #140: over-fetch when date filters active ──────────────────────────────
+
+describe('list over-fetches with --since (#140)', () => {
+  const now = Date.now();
+  const recentDate = new Date(now - 1000 * 60 * 60).toISOString(); // 1h ago
+  const oldDate = new Date(now - 1000 * 60 * 60 * 24 * 30).toISOString(); // 30d ago
+
+  test('sends larger limit to API when --since is used', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'r1', content: 'recent1', created_at: recentDate },
+        { id: 'r2', content: 'recent2', created_at: recentDate },
+        { id: 'old1', content: 'old', created_at: oldDate },
+      ],
+      total: 3,
+    };
+    allFetches.length = 0;
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdList({ _: ['list'], limit: '5', since: '7d' } as any);
+    restoreConsole();
+    resetOutputState();
+    // Should have over-fetched (limit > 5)
+    expect(lastFetchUrl).toContain('limit=100');
+    // Should pass since to server
+    expect(lastFetchUrl).toContain('since=');
+    // Output should only contain recent memories
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.memories.length).toBe(2);
+    expect(parsed.memories.every((m: any) => m.id.startsWith('r'))).toBe(true);
+  });
+
+  test('trims results to user limit after filtering', async () => {
+    // 10 recent memories, user requests 3
+    const recent = Array.from({ length: 10 }, (_, i) => ({
+      id: `mem-${i}`, content: `mem ${i}`, created_at: recentDate,
+    }));
+    mockFetchResponse = { memories: recent, total: 10 };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdList({ _: ['list'], limit: '3', since: '7d' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.memories.length).toBe(3);
+  });
+
+  test('does not over-fetch when no date filters', async () => {
+    mockFetchResponse = { memories: [], total: 0 };
+    allFetches.length = 0;
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdList({ _: ['list'], limit: '5' } as any);
+    restoreConsole();
+    resetOutputState();
+    expect(lastFetchUrl).toContain('limit=5');
+    expect(lastFetchUrl).not.toContain('since=');
+  });
+});
+
 // ─── #133: export CSV/TSV date filter fix ────────────────────────────────────
 
 describe('export CSV respects --since filter', () => {

--- a/test/dates.test.ts
+++ b/test/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { parseDate, filterByDateRange } from '../src/dates';
+import { parseDate, filterByDateRange, overfetchLimit } from '../src/dates';
 
 describe('parseDate', () => {
   test('parses ISO 8601 date', () => {
@@ -74,6 +74,27 @@ describe('parseDate', () => {
     expect(parseDate('')).toBeNull();
     expect(parseDate(null as any)).toBeNull();
     expect(parseDate(undefined as any)).toBeNull();
+  });
+});
+
+describe('overfetchLimit', () => {
+  test('returns 3x the requested limit', () => {
+    expect(overfetchLimit(20)).toBe(100); // 60 < min 100
+    expect(overfetchLimit(50)).toBe(150);
+  });
+
+  test('minimum is 100', () => {
+    expect(overfetchLimit(10)).toBe(100);
+    expect(overfetchLimit(1)).toBe(100);
+  });
+
+  test('maximum is 1000', () => {
+    expect(overfetchLimit(500)).toBe(1000);
+    expect(overfetchLimit(400)).toBe(1000);
+  });
+
+  test('defaults to 20 when undefined', () => {
+    expect(overfetchLimit(undefined)).toBe(100); // 20*3=60, min 100
   });
 });
 


### PR DESCRIPTION
## Problem
Commands using `--since`/`--until` (`list`, `search`, `recall`) applied date filtering client-side *after* the server returned `--limit` results, causing fewer results than expected.

## Fix
- When date filters are active, over-fetch from the API (3x requested limit, min 100, max 1000)
- Apply client-side date filtering on the larger result set
- Trim back to the user's requested limit
- Also pass `since`/`until` as query params for servers that support server-side filtering
- Added `overfetchLimit()` utility in `dates.ts`

## Tests
- 9 new tests (overfetchLimit unit tests + integration tests for list over-fetch behavior)
- All 540 tests pass

Fixes #140