### PR TITLE
fix: watch mode date trim + export --output flag

### DIFF
--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -5,7 +5,7 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputQuiet, outputFormat, out, success, warn, progressBar, outputWrite, readStdin } from '../output.js';
+import { outputJson, outputQuiet, outputFormat, outputFile, out, success, warn, progressBar, outputWrite, readStdin } from '../output.js';
 import { parseDate, filterByDateRange } from '../dates.js';
 
 export async function cmdExport(opts: ParsedArgs) {
@@ -76,7 +76,8 @@ export async function cmdExport(opts: ParsedArgs) {
   }
   if (!outputQuiet) {
     const filterNote = (sinceDate || untilDate) ? ` (filtered from ${allMemories.length})` : '';
-    console.error(`${c.green}✓${c.reset} Exported ${filteredMemories.length} memories${filterNote}`);
+    const destNote = outputFile ? ` → ${outputFile}` : '';
+    console.error(`${c.green}✓${c.reset} Exported ${filteredMemories.length} memories${filterNote}${destNote}`);
   }
 }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -148,6 +148,7 @@ export async function cmdList(opts: ParsedArgs) {
     let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
     const columns = buildColumns(opts);
+    const watchTrimLimit = hasDateFilter && userLimit ? userLimit : undefined;
 
     outputWrite(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
@@ -156,6 +157,7 @@ export async function cmdList(opts: ParsedArgs) {
         const result = await request('GET', `/v1/memories?${params}`) as any;
         let memories = result.memories || result.data || [];
         memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+        if (watchTrimLimit) memories = memories.slice(0, watchTrimLimit);
         const total = result.total ?? memories.length;
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -55,6 +55,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   if (opts.watch) {
     let lastFingerprint = '';
     const pollInterval = parseInt(opts.watchInterval || '5000');
+    const watchTrimLimit = hasDateFilter && userLimit ? userLimit : undefined;
 
     outputWrite(`${c.dim}Watching for changes... Press Ctrl+C to stop.${c.reset}`);
 
@@ -63,6 +64,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
         const result = await request('POST', '/v1/recall', body) as any;
         let memories = result.memories || [];
         memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+        if (watchTrimLimit) memories = memories.slice(0, watchTrimLimit);
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 
         if (fingerprint !== lastFingerprint) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -111,11 +111,13 @@ Examples:
 Export all memories as JSON. Useful for backups.
 
   ${c.dim}memoclaw export > backup.json${c.reset}
-  ${c.dim}memoclaw export --namespace project1 > project1.json${c.reset}
-  ${c.dim}memoclaw export --format csv > backup.csv${c.reset}
-  ${c.dim}memoclaw export --since 30d > recent.json${c.reset}
+  ${c.dim}memoclaw export -O backup.json${c.reset}
+  ${c.dim}memoclaw export --namespace project1 -O project1.json${c.reset}
+  ${c.dim}memoclaw export --format csv -O backup.csv${c.reset}
+  ${c.dim}memoclaw export --since 30d -O recent.json${c.reset}
 
 Options:
+  -O, --output <path>    Write directly to a file (instead of stdout)
   --namespace <name>     Filter by namespace
   --since <date>         Only memories created after date (ISO 8601 or 1h/7d/2w/1mo/1y)
   --until <date>         Only memories created before date

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -92,7 +92,7 @@ function resetOutputState(overrides: Record<string, any> = {}) {
     truncate: overrides.truncate,
     noTruncate: false,
     field: null,
-    output: null,
+    output: overrides.output ?? null,
   });
 }
 
@@ -2717,5 +2717,58 @@ describe('cmdMove', () => {
 
   test('throws if no namespace provided', async () => {
     expect(() => cmdMove(['id1'], { _: ['move'] } as any)).toThrow('Target namespace required');
+  });
+});
+
+// ─── #145: export --output flag ──────────────────────────────────────────────
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('export --output writes to file (#145)', () => {
+
+  test('export writes JSON to output file', async () => {
+    const tmpFile = path.join(os.tmpdir(), `memoclaw-test-export-${Date.now()}.json`);
+    const now = new Date().toISOString();
+    mockFetchResponse = {
+      memories: [
+        { id: 'exp1', content: 'hello', created_at: now, importance: 0.5, metadata: {} },
+      ],
+      total: 1,
+    };
+    resetOutputState({ output: tmpFile });
+    captureConsole();
+    await cmdExport({ _: ['export'], output: tmpFile } as any);
+    restoreConsole();
+    resetOutputState();
+    // File should exist and contain valid JSON with our memory
+    const content = fs.readFileSync(tmpFile, 'utf-8');
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.memories.length).toBe(1);
+    expect(parsed.memories[0].id).toBe('exp1');
+    // Clean up
+    fs.unlinkSync(tmpFile);
+  });
+
+  test('export CSV writes to output file', async () => {
+    const tmpFile = path.join(os.tmpdir(), `memoclaw-test-export-csv-${Date.now()}.csv`);
+    const now = new Date().toISOString();
+    mockFetchResponse = {
+      memories: [
+        { id: 'csv1', content: 'data', created_at: now, importance: 0.7, namespace: '', metadata: { tags: ['a'] } },
+      ],
+      total: 1,
+    };
+    resetOutputState({ format: 'csv', output: tmpFile });
+    captureConsole();
+    await cmdExport({ _: ['export'], format: 'csv', output: tmpFile } as any);
+    restoreConsole();
+    resetOutputState();
+    const content = fs.readFileSync(tmpFile, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines[0]).toContain('id');
+    expect(lines[1]).toContain('csv1');
+    fs.unlinkSync(tmpFile);
   });
 });


### PR DESCRIPTION
## Changes

### Fix #144 — Watch mode over-fetch trim
- `list --watch` and `recall --watch` now apply `trimLimit` after client-side date filtering, so results are trimmed back to the user's original `--limit` when `--since`/`--until` are active
- Previously, over-fetched results were returned unclipped in watch mode

### Fix #145 — Export `--output` flag
- The `--output` / `-O` flag already worked for export (via `outputWrite`), but was undocumented
- Added `-O, --output <path>` to export help text with examples
- Success message now shows the destination file path when `--output` is used
- Added tests for JSON and CSV export writing to file

### Tests
- 2 new tests for export `--output` (JSON + CSV file writing)
- All 542 tests pass

Fixes #144
Fixes #145