### PR TITLE
fix: shell escaping in edit command, improve completions, add copy --id-only

### DIFF
--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -4,9 +4,12 @@ export async function cmdCompletions(shell: string) {
     'completions', 'config', 'graph', 'history', 'purge', 'count', 'tags', 'namespace', 'whoami', 'upgrade', 'help'];
 
   const globalFlags = ['--help', '--version', '--json', '--quiet', '--namespace', '--limit', '--offset',
-    '--tags', '--format', '--pretty', '--watch', '--raw', '--force', '--output', '--truncate',
+    '--tags', '--format', '--pretty', '--watch', '--watch-interval', '--raw', '--force', '--output', '--truncate',
     '--no-truncate', '--columns', '--sort-by', '--reverse', '--wide', '--concurrency', '--yes',
-    '--timeout', '--field', '--dry-run'];
+    '--timeout', '--field', '--dry-run', '--since', '--until', '--retries', '--no-retry',
+    '--min-similarity', '--memory-type', '--batch', '--id-only', '--content', '--file',
+    '--importance', '--immutable', '--pinned', '--session-id', '--agent-id', '--expires-at',
+    '--editor', '--interval', '--no-color', '--check', '--all', '--revision'];
 
   if (shell === 'bash') {
     console.log(`# Add to ~/.bashrc:

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -171,8 +171,8 @@ export async function cmdEdit(id: string, opts?: ParsedArgs) {
   writeFileSync(tmpFile, originalContent, 'utf-8');
 
   try {
-    // Open in editor
-    execSync(`${editor} ${tmpFile}`, { stdio: 'inherit' });
+    // Open in editor (quote path to handle spaces in tmpdir)
+    execSync(`${editor} "${tmpFile}"`, { stdio: 'inherit' });
 
     // Read back
     const newContent = readFileSync(tmpFile, 'utf-8');
@@ -228,7 +228,9 @@ export async function cmdCopy(id: string, opts: ParsedArgs) {
   // Deliberately do NOT copy immutable flag — new memory should be mutable
 
   const storeResult = await request('POST', '/v1/store', body) as any;
-  if (outputJson) {
+  if (opts.idOnly) {
+    outputWrite(storeResult.id || '');
+  } else if (outputJson) {
     out({ source: id, id: storeResult.id, copied: true });
   } else {
     success(`Copied ${c.cyan}${id.slice(0, 8)}…${c.reset} → ${c.cyan}${(storeResult.id || '?').slice(0, 8)}…${c.reset}`);

--- a/src/help.ts
+++ b/src/help.ts
@@ -269,7 +269,8 @@ Options:
   --namespace <name>     Target namespace (default: same as source)
   --importance <0-1>     Override importance score
   --tags <tag1,tag2>     Override tags
-  --memory-type <type>   Override memory type`,
+  --memory-type <type>   Override memory type
+  --id-only              Print only the new memory ID (for scripting)`,
 
       move: `${c.bold}memoclaw move${c.reset} <id> [<id2> ...] --namespace <target>
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -2698,6 +2698,23 @@ describe('cmdCopy', () => {
     resetOutputState();
     expect(storeBody.namespace).toBe('new-ns');
   });
+
+  test('copy with --id-only outputs only the new ID', async () => {
+    let callCount = 0;
+    mockFetchResponse = (url: string, init: any) => {
+      callCount++;
+      if (callCount === 1) {
+        return { memory: { id: 'source-id', content: 'hello' } };
+      }
+      return { id: 'new-copy-id' };
+    };
+    resetOutputState({});
+    captureConsole();
+    await cmdCopy('source-id', { _: ['copy'], idOnly: true } as any);
+    restoreConsole();
+    resetOutputState();
+    expect(consoleOutput.join('').trim()).toBe('new-copy-id');
+  });
 });
 
 // ─── #136: move command ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Bug fix: Shell escaping in `edit` command
`cmdEdit` used `execSync(\`${editor} ${tmpFile}\`)` without quoting the temp file path. This would break if the system temp directory contains spaces. Fixed by quoting the path.

### Enhancement: Add `--id-only` flag to `copy` command (Fixes #148)
For scripting consistency with `store --id-only`, the `copy` command now supports `--id-only` to output just the new memory ID.

```bash
NEW_ID=$(memoclaw copy abc123 --id-only)
```

### Enhancement: Expand shell completions
Added 20+ missing flags to the completions output for bash/zsh/fish:
`--since`, `--until`, `--retries`, `--no-retry`, `--min-similarity`, `--memory-type`, `--batch`, `--id-only`, `--content`, `--file`, `--importance`, `--immutable`, `--pinned`, `--session-id`, `--agent-id`, `--expires-at`, `--editor`, `--interval`, `--no-color`, `--check`, `--all`, `--revision`, `--watch-interval`

### Tests
- Added test for `copy --id-only` output
- All 543 tests pass