### PR TITLE
feat: detect package manager for upgrade command

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -87,16 +87,48 @@ export async function checkForUpdate(forceRefresh = false): Promise<VersionCheck
   };
 }
 
-/** Install the latest version */
-export function installUpdate(): { success: boolean; output: string } {
+/** Detect which package manager was used to install the CLI */
+export function detectPackageManager(): string {
+  // Check the resolved path of the running CLI to guess the installer
   try {
-    const output = execSync('npm install -g memoclaw@latest 2>&1', {
+    const cliPath = process.argv[1] || '';
+    if (cliPath.includes('.bun')) return 'bun';
+    if (cliPath.includes('pnpm')) return 'pnpm';
+    if (cliPath.includes('yarn')) return 'yarn';
+  } catch {}
+
+  // Fallback: check if common managers are available, prefer bun if present
+  try {
+    execSync('bun --version', { stdio: 'ignore', timeout: 3000 });
+    // Only prefer bun if npm path suggests non-npm install
+    // Default to npm since it's the published registry
+  } catch {}
+
+  return 'npm';
+}
+
+/** Build the install command for a given package manager */
+export function buildInstallCommand(pm: string): string {
+  switch (pm) {
+    case 'bun': return 'bun install -g memoclaw@latest';
+    case 'pnpm': return 'pnpm add -g memoclaw@latest';
+    case 'yarn': return 'yarn global add memoclaw@latest';
+    default: return 'npm install -g memoclaw@latest';
+  }
+}
+
+/** Install the latest version */
+export function installUpdate(): { success: boolean; output: string; packageManager: string } {
+  const pm = detectPackageManager();
+  const cmd = buildInstallCommand(pm);
+  try {
+    const output = execSync(`${cmd} 2>&1`, {
       encoding: 'utf-8',
       timeout: 60_000,
     });
-    return { success: true, output: output.trim() };
+    return { success: true, output: output.trim(), packageManager: pm };
   } catch (err: any) {
-    return { success: false, output: err.message || String(err) };
+    return { success: false, output: err.message || String(err), packageManager: pm };
   }
 }
 
@@ -192,7 +224,8 @@ export async function cmdUpgrade(opts: ParsedArgs) {
     } else {
       outputWrite(`${c.red}Error:${c.reset} Failed to install update.`);
       outputWrite(`${c.dim}${installResult.output}${c.reset}`);
-      outputWrite(`\nTry manually: ${c.cyan}npm install -g memoclaw@latest${c.reset}`);
+      const manualCmd = buildInstallCommand(installResult.packageManager);
+      outputWrite(`\nTry manually: ${c.cyan}${manualCmd}${c.reset}`);
     }
     process.exit(1);
   }

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { compareSemver, type VersionCheckResult } from '../src/commands/upgrade';
+import { compareSemver, detectPackageManager, buildInstallCommand, type VersionCheckResult } from '../src/commands/upgrade';
 import { parseArgs, BOOLEAN_FLAGS } from '../src/args';
 
 // ─── Version comparison ─────────────────────────────────────────────────────
@@ -74,6 +74,38 @@ describe('VersionCheckResult', () => {
       updateAvailable: compareSemver('2.0.0', '1.9.0') < 0,
     };
     expect(result.updateAvailable).toBe(false);
+  });
+});
+
+// ─── Package manager detection (Fixes #152) ──────────────────────────────────
+
+describe('detectPackageManager', () => {
+  test('returns a string', () => {
+    const pm = detectPackageManager();
+    expect(typeof pm).toBe('string');
+    expect(['npm', 'bun', 'pnpm', 'yarn']).toContain(pm);
+  });
+});
+
+describe('buildInstallCommand', () => {
+  test('npm', () => {
+    expect(buildInstallCommand('npm')).toBe('npm install -g memoclaw@latest');
+  });
+
+  test('bun', () => {
+    expect(buildInstallCommand('bun')).toBe('bun install -g memoclaw@latest');
+  });
+
+  test('pnpm', () => {
+    expect(buildInstallCommand('pnpm')).toBe('pnpm add -g memoclaw@latest');
+  });
+
+  test('yarn', () => {
+    expect(buildInstallCommand('yarn')).toBe('yarn global add memoclaw@latest');
+  });
+
+  test('unknown defaults to npm', () => {
+    expect(buildInstallCommand('unknown')).toBe('npm install -g memoclaw@latest');
   });
 });
 


### PR DESCRIPTION
## Changes

### Enhancement: Detect package manager for upgrades (Fixes #152)

`memoclaw upgrade` previously hardcoded `npm install -g memoclaw@latest`. If the CLI was installed with bun, pnpm, or yarn, this would either fail or install a conflicting copy.

Now it detects the package manager from the CLI binary path and uses the correct upgrade command:

| Installer | Upgrade command |
|-----------|----------------|
| npm | `npm install -g memoclaw@latest` |
| bun | `bun install -g memoclaw@latest` |
| pnpm | `pnpm add -g memoclaw@latest` |
| yarn | `yarn global add memoclaw@latest` |

Detection checks if the running binary path contains `.bun`, `pnpm`, or `yarn`. Falls back to npm if unknown.

### Tests
- 6 new tests for `detectPackageManager()` and `buildInstallCommand()`
- All 556 tests pass