### PR TITLE
fix: batch store --file, purge date-filter offset, completions flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,8 +103,14 @@ try {
   switch (cmd) {
     case 'store': {
       if (args.batch) {
-        const stdin = await readStdin();
-        const lines = stdin ? stdin.split('\n') : [];
+        let batchText: string | null = null;
+        if (args.file) {
+          batchText = readFileContent(args.file);
+        }
+        if (!batchText) {
+          batchText = await readStdin();
+        }
+        const lines = batchText ? batchText.split('\n') : [];
         await cmdStoreBatch(args, lines);
         break;
       }

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -9,7 +9,8 @@ export async function cmdCompletions(shell: string) {
     '--timeout', '--field', '--dry-run', '--since', '--until', '--retries', '--no-retry',
     '--min-similarity', '--memory-type', '--batch', '--id-only', '--content', '--file',
     '--importance', '--immutable', '--pinned', '--session-id', '--agent-id', '--expires-at',
-    '--editor', '--interval', '--no-color', '--check', '--all', '--revision'];
+    '--editor', '--interval', '--no-color', '--check', '--all', '--revision',
+    '--auto-relate', '--category', '--url'];
 
   if (shell === 'bash') {
     console.log(`# Add to ~/.bashrc:

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -226,12 +226,13 @@ export async function cmdPurge(opts: ParsedArgs) {
 
     // Apply date filters client-side when --since/--until are provided
     if (hasDateFilter) {
+      const pageSize = result.memories?.length || result.data?.length || memories.length;
       const filtered = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
-      const skipped = memories.length - filtered.length;
+      const skipped = pageSize - filtered.length;
       memories = filtered;
-      // Advance offset past non-matching memories
+      // Advance offset past non-matching memories only
       if (memories.length === 0) {
-        offset += result.memories?.length || result.data?.length || 100;
+        offset += pageSize;
         // If we've gone past all results, stop
         if (result.total !== undefined && offset >= result.total) break;
         failedInRow++;
@@ -279,10 +280,13 @@ export async function cmdPurge(opts: ParsedArgs) {
       }
     }
 
-    // When date filtering, advance offset since we're not deleting everything in the page
+    // When date filtering, advance offset past only the non-deleted (skipped) items.
+    // Deleted items are removed from the dataset, so the remaining items shift
+    // forward. We only need to advance past items we did NOT delete.
     if (hasDateFilter) {
-      offset += 100;
-      if (result.total !== undefined && offset >= result.total) break;
+      const origPageSize = (result.memories || result.data || []).length;
+      offset += (origPageSize - batchDeleted);
+      if (result.total !== undefined && offset >= result.total - deleted) break;
     }
   }
 


### PR DESCRIPTION
## Changes

### Bug Fixes

1. **store --batch ignores --file flag** (Fixes #164)
   - The batch store path now reads from `--file` before falling back to stdin
   - Single store already supported this; batch mode was missing it

2. **purge --since/--until can skip memories** (Fixes #165)
   - When date-filtering during purge, offset was advanced by a fixed 100 per page
   - But deleted items shift the dataset, causing memories to be skipped
   - Now advances offset by `(pageSize - deletedCount)` to account for the shift

3. **Completions missing flags** (Fixes #166)
   - Added `--auto-relate`, `--category`, `--url` to shell completions

## Testing

All 568 existing tests pass. Build succeeds.