### PR TITLE
fix: list --raw sort, watch listener leak, recall --watch IDs

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -210,6 +210,7 @@ export async function cmdList(opts: ParsedArgs) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
     if (trimLimit) memories = memories.slice(0, trimLimit);
+    memories = sortMemories(memories, opts);
     for (const mem of memories) {
       outputWrite(mem.content || '');
     }

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -87,7 +87,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
               outputWrite(mem.content);
             }
           } else {
-            renderMemories(memories);
+            renderMemories(memories, { showId: true });
           }
         }
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -94,6 +94,9 @@ export async function cmdWatch(opts: ParsedArgs) {
     }
   }
 
+  process.removeListener('SIGINT', cleanup);
+  process.removeListener('SIGTERM', cleanup);
+
   if (!outputJson) {
     outputWrite(`\n${c.dim}Stopped watching.${c.reset}`);
   }


### PR DESCRIPTION
## Changes

Fixes 3 bugs found during code audit:

### 1. `list --raw --sort-by` doesn't apply sorting (Fixes #168)
The raw output path in `cmdList` was missing the `sortMemories()` call that the table and csv/yaml paths both had.

### 2. `watch` command leaks SIGINT/SIGTERM listeners (Fixes #169)
The watch command registered signal handlers but never removed them after the loop exited. Added cleanup with `process.removeListener()`.

### 3. `recall --watch` doesn't show memory IDs (Fixes #170)
The watch-mode branch in `cmdRecall` called `renderMemories(memories)` without `{ showId: true }`, unlike the non-watch path. Now consistent.

## Testing
All 568 existing tests pass.