### PR TITLE
feat: search --sort-by/--reverse + CSV newline flattening

### DIFF
--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -61,8 +61,10 @@ export async function cmdExport(opts: ParsedArgs) {
           m.metadata?.tags?.join(';') || '',
           m.created_at || '',
         ].map(v => {
-          if (outputFormat === 'csv' && (v.includes(',') || v.includes('"') || v.includes('\n'))) {
-            return `"${v.replace(/"/g, '""')}"`;
+          if (outputFormat === 'csv') {
+            // Flatten newlines to spaces for CSV portability (#172)
+            const flat = v.replace(/\r?\n/g, ' ');
+            return flat.includes(',') || flat.includes('"') ? `"${flat.replace(/"/g, '""')}"` : flat;
           }
           return outputFormat === 'tsv' ? v.replace(/[\t\n]/g, ' ') : v;
         });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -5,7 +5,7 @@ import { outputJson, outputFormat, outputTruncate, noTruncate, out, table, outpu
 import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
 
 /** Apply client-side sorting to memories array */
-function sortMemories(memories: any[], opts: ParsedArgs): any[] {
+export function sortMemories(memories: any[], opts: ParsedArgs): any[] {
   if (!opts.sortBy || memories.length === 0) return memories;
 
   const sortKey = opts.sortBy;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -8,6 +8,7 @@ import { c } from '../colors.js';
 import { outputJson, outputFormat, outputTruncate, noTruncate, out, outputWrite, success, info, truncate, table, readStdin } from '../output.js';
 import { validateContentLength, validateBulkContentLength } from '../validate.js';
 import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
+import { sortMemories } from './list.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
   const params = new URLSearchParams({ q: query });
@@ -40,14 +41,18 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     if (hasDateFilter) {
       let filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
       if (trimLimit) filtered = filtered.slice(0, trimLimit);
+      filtered = sortMemories(filtered, opts);
       out({ ...result, memories: filtered });
     } else {
-      out(result);
+      let memories = result.memories || result.data || [];
+      memories = sortMemories(memories, opts);
+      out({ ...result, memories });
     }
   } else if (opts.raw) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
     if (trimLimit) memories = memories.slice(0, trimLimit);
+    memories = sortMemories(memories, opts);
     for (const mem of memories) {
       outputWrite(mem.content);
     }
@@ -55,6 +60,7 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
     if (trimLimit) memories = memories.slice(0, trimLimit);
+    memories = sortMemories(memories, opts);
     const rows = memories.map((m: any) => ({
       id: m.id || '',
       content: m.content || '',
@@ -65,6 +71,7 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
     let memories = result.memories || result.data || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
     if (trimLimit) memories = memories.slice(0, trimLimit);
+    memories = sortMemories(memories, opts);
     if (memories.length === 0) {
       outputWrite(`${c.dim}No memories found.${c.reset}`);
     } else {

--- a/src/help.ts
+++ b/src/help.ts
@@ -48,6 +48,8 @@ Options:
   --tags <tag1,tag2>     Filter by tags
   --since <date>         Only memories created after date (ISO 8601 or 1h/7d/2w/1mo/1y)
   --until <date>         Only memories created before date
+  --sort-by <field>      Sort by field (id, importance, created, updated)
+  --reverse              Reverse sort order
   --format <fmt>         Output format: json, csv, tsv, yaml
   --raw                  Output content only (for piping)`,
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -120,7 +120,9 @@ export function out(data: any) {
           const val = row[h];
           const str = val === null || val === undefined ? '' : String(val);
           if (outputFormat === 'csv') {
-            return str.includes(',') || str.includes('"') ? `"${str.replace(/"/g, '""')}"` : str;
+            // Replace newlines with spaces for CSV portability (matches TSV behavior)
+            const flat = str.replace(/\r?\n/g, ' ');
+            return flat.includes(',') || flat.includes('"') ? `"${flat.replace(/"/g, '""')}"` : flat;
           }
           return str.replace(/\t/g, ' ').replace(/\n/g, ' ');
         }).join(sep));

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3028,3 +3028,149 @@ describe('watch respects --format flag (Fixes #154)', () => {
     expect(typeof watchMod.cmdWatch).toBe('function');
   });
 });
+
+// ─── #171: search --sort-by and --reverse ─────────────────────────────────────
+
+describe('search --sort-by and --reverse (Fixes #171)', () => {
+  test('sorts search results by importance', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'sort-aaa', content: 'low', importance: 0.2, metadata: {} },
+        { id: 'sort-bbb', content: 'high', importance: 0.9, metadata: {} },
+        { id: 'sort-ccc', content: 'mid', importance: 0.5, metadata: {} },
+      ],
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSearch('test', { _: [], sortBy: 'importance' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    const importances = parsed.memories.map((m: any) => m.importance);
+    expect(importances).toEqual([0.2, 0.5, 0.9]);
+  });
+
+  test('sorts search results by importance reversed', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'sort-aaa', content: 'low', importance: 0.2, metadata: {} },
+        { id: 'sort-bbb', content: 'high', importance: 0.9, metadata: {} },
+        { id: 'sort-ccc', content: 'mid', importance: 0.5, metadata: {} },
+      ],
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSearch('test', { _: [], sortBy: 'importance', reverse: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    const importances = parsed.memories.map((m: any) => m.importance);
+    expect(importances).toEqual([0.9, 0.5, 0.2]);
+  });
+
+  test('sorts search results by created date', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'sort-aaa', content: 'newer', created_at: '2026-03-10T00:00:00Z', metadata: {} },
+        { id: 'sort-bbb', content: 'older', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      ],
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSearch('test', { _: [], sortBy: 'created' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.memories[0].id).toBe('sort-bbb');
+    expect(parsed.memories[1].id).toBe('sort-aaa');
+  });
+
+  test('sort applies in raw mode', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'sort-aaa', content: 'low-imp', importance: 0.2, metadata: {} },
+        { id: 'sort-bbb', content: 'high-imp', importance: 0.9, metadata: {} },
+      ],
+    };
+    resetOutputState();
+    captureConsole();
+    await cmdSearch('test', { _: [], sortBy: 'importance', reverse: true, raw: true } as any);
+    restoreConsole();
+    resetOutputState();
+    expect(consoleOutput[0]).toBe('high-imp');
+    expect(consoleOutput[1]).toBe('low-imp');
+  });
+
+  test('sort applies in csv mode', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'sort-aaa', content: 'low-imp', importance: 0.2, metadata: {} },
+        { id: 'sort-bbb', content: 'high-imp', importance: 0.9, metadata: {} },
+      ],
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdSearch('test', { _: [], sortBy: 'importance', reverse: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    const lines = output.split('\n');
+    // Header + 2 rows; first data row should be high-imp
+    expect(lines[1]).toContain('high-imp');
+    expect(lines[2]).toContain('low-imp');
+  });
+});
+
+// ─── #172: CSV export newline escaping ────────────────────────────────────────
+
+describe('CSV newline escaping (Fixes #172)', () => {
+  test('out() flattens newlines in CSV content', async () => {
+    resetOutputState();
+    const { configureOutput, out } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    out([{ id: 'test-1', content: 'line one\nline two\nline three' }]);
+    restoreConsole();
+    resetOutputState();
+    const output = consoleOutput.join('\n');
+    // Should NOT contain literal newlines within a row
+    const lines = output.split('\n');
+    // Header + 1 data row = 2 lines
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('line one line two line three');
+  });
+
+  test('out() flattens \\r\\n in CSV content', async () => {
+    resetOutputState();
+    const { configureOutput, out } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    out([{ id: 'test-1', content: 'first\r\nsecond' }]);
+    restoreConsole();
+    resetOutputState();
+    const lines = consoleOutput.join('\n').split('\n');
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('first second');
+  });
+
+  test('search CSV output flattens newlines in content', async () => {
+    mockFetchResponse = {
+      memories: [
+        { id: 'nl-1111-2222', content: 'hello\nworld\nfoo', metadata: { tags: ['t1'] } },
+      ],
+    };
+    resetOutputState();
+    const { configureOutput } = await import('../src/output.js');
+    configureOutput({ format: 'csv' });
+    captureConsole();
+    await cmdSearch('hello', { _: [] } as any);
+    restoreConsole();
+    resetOutputState();
+    const lines = consoleOutput.join('\n').split('\n');
+    // Header + 1 data row = 2 lines
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('hello world foo');
+  });
+});


### PR DESCRIPTION
## Changes

### Search sorting (Fixes #171)
- Export `sortMemories` from `list.ts` and apply it in all `cmdSearch` output paths (JSON, raw, csv/tsv/yaml, table)
- `memoclaw search "query" --sort-by importance --reverse` now works as expected
- Updated search help text to document `--sort-by` and `--reverse`

### CSV newline flattening (Fixes #172)
- Flatten `\n` and `\r\n` to spaces in CSV output in both the generic `out()` function (`output.ts`) and `cmdExport` (`data.ts`)
- Matches existing TSV behavior for portability with Excel/Google Sheets
- Fields containing commas or quotes are still properly quoted

### Tests
- 8 new tests covering sort in search (JSON, raw, csv modes) and CSV newline flattening
- All 576 tests pass

Fixes #171
Fixes #172