### PR TITLE
fix: audit batch — 5 bugs/improvements (#181-#185)

### DIFF
--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -216,83 +216,109 @@ export async function cmdPurge(opts: ParsedArgs) {
     }
   }
 
+  // When date-filtering, collect all matching IDs first to avoid offset drift (#185)
+  let idsToDelete: string[] = [];
+
+  if (hasDateFilter) {
+    const params = new URLSearchParams({ limit: '1000' });
+    if (opts.namespace) params.set('namespace', opts.namespace);
+    let offset = 0;
+
+    while (true) {
+      params.set('offset', String(offset));
+      const result = await request('GET', `/v1/memories?${params}`) as any;
+      const memories = result.memories || result.data || [];
+      if (memories.length === 0) break;
+      const matching = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+      idsToDelete.push(...matching.map((m: any) => m.id));
+      if (memories.length < 1000) break;
+      offset += 1000;
+      if (!outputQuiet) process.stderr.write(`\r  ${c.dim}Scanning... ${idsToDelete.length} matching${c.reset}`);
+    }
+    if (!outputQuiet && idsToDelete.length > 0) process.stderr.write('\r' + ' '.repeat(60) + '\r');
+  }
+
   const params = new URLSearchParams({ limit: '100' });
   if (opts.namespace) params.set('namespace', opts.namespace);
   let deleted = 0;
   let failedInRow = 0;
   const MAX_CONSECUTIVE_FAILURES = 3;
   let useBulk = true;
-  let offset = 0;
 
-  while (true) {
-    params.set('offset', hasDateFilter ? String(offset) : '0');
-    const result = await request('GET', `/v1/memories?${params}`) as any;
-    let memories = result.memories || result.data || [];
-    if (memories.length === 0) break;
+  if (hasDateFilter) {
+    // Delete collected IDs in batches
+    for (let i = 0; i < idsToDelete.length; i += 100) {
+      const batch = idsToDelete.slice(i, i + 100);
+      let batchDeleted = 0;
 
-    // Apply date filters client-side when --since/--until are provided
-    if (hasDateFilter) {
-      const pageSize = result.memories?.length || result.data?.length || memories.length;
-      const filtered = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
-      const skipped = pageSize - filtered.length;
-      memories = filtered;
-      // Advance offset past non-matching memories only
-      if (memories.length === 0) {
-        offset += pageSize;
-        // If we've gone past all results, stop
-        if (result.total !== undefined && offset >= result.total) break;
-        failedInRow++;
-        if (failedInRow >= MAX_CONSECUTIVE_FAILURES * 2) break;
-        continue;
-      }
-      failedInRow = 0;
-    }
-
-    const ids = memories.map((m: any) => m.id);
-    let batchDeleted = 0;
-
-    if (useBulk) {
-      try {
-        const bulkResult = await request('POST', '/v1/memories/bulk-delete', { ids }) as any;
-        batchDeleted = bulkResult.deleted ?? ids.length;
-        deleted += batchDeleted;
-        failedInRow = 0;
-        if (!outputQuiet) process.stderr.write(`\r  ${progressBar(deleted, hasDateFilter ? deleted : (result.total || deleted))}`);
-      } catch {
-        // Bulk delete not available, fall back to one-by-one
-        useBulk = false;
-      }
-    }
-
-    if (!useBulk) {
-      for (const mem of memories) {
+      if (useBulk) {
         try {
-          await request('DELETE', `/v1/memories/${mem.id}`);
-          deleted++;
-          batchDeleted++;
-          failedInRow = 0;
-          if (!outputQuiet) process.stderr.write(`\r  ${progressBar(deleted, hasDateFilter ? deleted : (result.total || deleted))}`);
-        } catch (e: any) {
-          if (process.env.DEBUG) console.error(`\nFailed to delete ${mem.id}: ${e.message}`);
+          const bulkResult = await request('POST', '/v1/memories/bulk-delete', { ids: batch }) as any;
+          batchDeleted = bulkResult.deleted ?? batch.length;
+          deleted += batchDeleted;
+        } catch {
+          useBulk = false;
         }
       }
-    }
 
-    if (batchDeleted === 0) {
-      failedInRow++;
-      if (failedInRow >= MAX_CONSECUTIVE_FAILURES) {
-        warn(`Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batches failed to delete any memories`);
-        break;
+      if (!useBulk) {
+        for (const id of batch) {
+          try {
+            await request('DELETE', `/v1/memories/${id}`);
+            deleted++;
+            batchDeleted++;
+          } catch (e: any) {
+            if (process.env.DEBUG) console.error(`\nFailed to delete ${id}: ${e.message}`);
+          }
+        }
       }
-    }
 
-    // When date filtering, advance offset past only the non-deleted (skipped) items.
-    // Deleted items are removed from the dataset, so the remaining items shift
-    // forward. We only need to advance past items we did NOT delete.
-    if (hasDateFilter) {
-      const origPageSize = (result.memories || result.data || []).length;
-      offset += (origPageSize - batchDeleted);
-      if (result.total !== undefined && offset >= result.total - deleted) break;
+      if (!outputQuiet) process.stderr.write(`\r  ${progressBar(deleted, idsToDelete.length)}`);
+    }
+  } else {
+    // No date filter — delete all, page from offset 0 each time
+    while (true) {
+      params.set('offset', '0');
+      const result = await request('GET', `/v1/memories?${params}`) as any;
+      const memories = result.memories || result.data || [];
+      if (memories.length === 0) break;
+
+      const ids = memories.map((m: any) => m.id);
+      let batchDeleted = 0;
+
+      if (useBulk) {
+        try {
+          const bulkResult = await request('POST', '/v1/memories/bulk-delete', { ids }) as any;
+          batchDeleted = bulkResult.deleted ?? ids.length;
+          deleted += batchDeleted;
+          failedInRow = 0;
+        } catch {
+          useBulk = false;
+        }
+      }
+
+      if (!useBulk) {
+        for (const mem of memories) {
+          try {
+            await request('DELETE', `/v1/memories/${mem.id}`);
+            deleted++;
+            batchDeleted++;
+            failedInRow = 0;
+          } catch (e: any) {
+            if (process.env.DEBUG) console.error(`\nFailed to delete ${mem.id}: ${e.message}`);
+          }
+        }
+      }
+
+      if (batchDeleted === 0) {
+        failedInRow++;
+        if (failedInRow >= MAX_CONSECUTIVE_FAILURES) {
+          warn(`Aborting: ${MAX_CONSECUTIVE_FAILURES} consecutive batches failed to delete any memories`);
+          break;
+        }
+      }
+
+      if (!outputQuiet) process.stderr.write(`\r  ${progressBar(deleted, result.total || deleted)}`);
     }
   }
 

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -9,12 +9,20 @@ import { outputJson, outputFormat, out, outputWrite, table } from '../output.js'
 
 export async function cmdHistory(id: string, opts?: ParsedArgs) {
   const result = await request('GET', `/v1/memories/${id}/history`) as any;
+
+  let history = result.history || [];
+
+  // Apply --limit: show only the N most recent entries
+  const userLimit = opts?.limit != null && opts.limit !== true ? parseInt(opts.limit) : undefined;
+  if (userLimit != null && userLimit > 0) {
+    history = history.slice(-userLimit);
+  }
+
   if (outputJson) {
-    out(result);
+    out({ ...result, history });
     return;
   }
 
-  const history = result.history || [];
   if (history.length === 0) {
     outputWrite(`${c.dim}No history entries found.${c.reset}`);
     return;

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -79,7 +79,9 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
               similarity: m.similarity?.toFixed(3) || '',
               content: m.content || '',
               importance: m.importance?.toFixed(2) || '',
+              namespace: m.namespace || '',
               tags: m.metadata?.tags?.join(', ') || '',
+              created: m.created_at || '',
             }));
             out(rows);
           } else if (opts.raw) {
@@ -118,7 +120,9 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
       similarity: m.similarity?.toFixed(3) || '',
       content: m.content || '',
       importance: m.importance?.toFixed(2) || '',
+      namespace: m.namespace || '',
       tags: m.metadata?.tags?.join(', ') || '',
+      created: m.created_at || '',
     }));
     out(rows);
   } else if (opts.raw) {

--- a/src/commands/tags.ts
+++ b/src/commands/tags.ts
@@ -3,9 +3,9 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, out, outputWrite, table } from '../output.js';
 
-/** Fetch all unique tags by paginating through memories */
-async function fetchAllTags(opts: ParsedArgs): Promise<string[]> {
-  const tagSet = new Set<string>();
+/** Fetch all unique tags (with counts) by paginating through memories */
+async function fetchAllTags(opts: ParsedArgs): Promise<{ tag: string; count: number }[]> {
+  const tagCounts = new Map<string, number>();
   const pageSize = 1000;
   let offset = 0;
 
@@ -17,29 +17,36 @@ async function fetchAllTags(opts: ParsedArgs): Promise<string[]> {
     for (const mem of memories) {
       const tags = mem.metadata?.tags || [];
       for (const tag of tags) {
-        if (tag && typeof tag === 'string') tagSet.add(tag);
+        if (tag && typeof tag === 'string') {
+          tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+        }
       }
     }
     if (memories.length < pageSize) break;
     offset += pageSize;
   }
 
-  return [...tagSet].sort((a, b) => a.localeCompare(b));
+  return [...tagCounts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
 }
 
 export async function cmdTags(subcmd: string, rest: string[], opts: ParsedArgs) {
   if (subcmd === 'list' || !subcmd) {
-    const tags = await fetchAllTags(opts);
+    const tagData = await fetchAllTags(opts);
 
     if (outputJson) {
-      out({ tags, count: tags.length });
+      out({ tags: tagData.map(t => ({ tag: t.tag, count: t.count })), count: tagData.length });
     } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
-      out(tags.map(tag => ({ tag })));
-    } else if (tags.length === 0) {
+      out(tagData.map(t => ({ tag: t.tag, count: t.count })));
+    } else if (tagData.length === 0) {
       outputWrite(`${c.dim}No tags found.${c.reset}`);
     } else {
-      table(tags.map(tag => ({ tag })), [{ key: 'tag', label: 'TAG', width: 30 }]);
-      outputWrite(`${c.dim}─ ${tags.length} tag${tags.length !== 1 ? 's' : ''}${c.reset}`);
+      table(tagData.map(t => ({ tag: t.tag, count: String(t.count) })), [
+        { key: 'tag', label: 'TAG', width: 30 },
+        { key: 'count', label: 'COUNT', width: 8 },
+      ]);
+      outputWrite(`${c.dim}─ ${tagData.length} tag${tagData.length !== 1 ? 's' : ''}${c.reset}`);
     }
   } else {
     throw new Error('Usage: tags [list]');

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -6,6 +6,7 @@ import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputFormat, out, outputWrite, table } from '../output.js';
+import { sortMemories } from './list.js';
 
 export async function cmdWatch(opts: ParsedArgs) {
   const interval = parseInt(opts.interval || '3') * 1000;
@@ -48,8 +49,8 @@ export async function cmdWatch(opts: ParsedArgs) {
         // Update last-seen to the newest
         lastSeenTimestamp = newMemories[0].created_at || lastSeenTimestamp;
 
-        // Display newest-last (chronological order)
-        const sorted = [...newMemories].reverse();
+        // Apply user sorting if specified, otherwise chronological (newest-last)
+        const sorted = (opts.sortBy) ? sortMemories([...newMemories], opts) : [...newMemories].reverse();
 
         for (const mem of sorted) {
           if (outputJson) {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -2495,7 +2495,11 @@ describe('cmdTags', () => {
     restoreConsole();
     resetOutputState();
     const parsed = JSON.parse(consoleOutput.join(''));
-    expect(parsed.tags).toEqual(['alpha', 'beta', 'gamma']);
+    expect(parsed.tags).toEqual([
+      { tag: 'alpha', count: 1 },
+      { tag: 'beta', count: 2 },
+      { tag: 'gamma', count: 1 },
+    ]);
     expect(parsed.count).toBe(3);
   });
 
@@ -2529,7 +2533,7 @@ describe('cmdTags', () => {
     restoreConsole();
     resetOutputState();
     const parsed = JSON.parse(consoleOutput.join(''));
-    expect(parsed.tags).toEqual(['same']);
+    expect(parsed.tags).toEqual([{ tag: 'same', count: 3 }]);
     expect(parsed.count).toBe(1);
   });
 
@@ -2546,7 +2550,7 @@ describe('cmdTags', () => {
     restoreConsole();
     resetOutputState();
     const parsed = JSON.parse(consoleOutput.join(''));
-    expect(parsed.tags).toEqual(['apple', 'mango', 'zebra']);
+    expect(parsed.tags.map((t: any) => t.tag)).toEqual(['apple', 'mango', 'zebra']);
   });
 
   test('csv format outputs rows', async () => {


### PR DESCRIPTION
## Changes

- **fix: recall CSV/TSV output now includes namespace and created columns** (#181)
  - `recall --format csv` now matches `list --format csv` column set (id, content, importance, namespace, tags, created)

- **fix: watch command applies --sort-by/--reverse flags** (#182)
  - `memoclaw watch --sort-by importance --reverse` now sorts results before display

- **feat: history command supports --limit** (#183)
  - `memoclaw history <id> --limit 5` shows only the N most recent entries

- **feat: tags list shows per-tag memory count** (#184)
  - `memoclaw tags list` now displays how many memories use each tag

- **fix: purge with date filters uses two-pass collect-then-delete** (#185)
  - Eliminates offset drift that could skip memories during date-filtered purge
  - First scans all matching memory IDs, then deletes in batches

## Testing
All 581 tests pass.

Fixes #181, Fixes #182, Fixes #183, Fixes #184, Fixes #185