### PR TITLE
fix: batch namespace empty-string override + recall --sort-by support (#189, #192)

### DIFF
--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -3,6 +3,7 @@ import { request } from '../http.js';
 import { c } from '../colors.js';
 import { outputJson, outputTruncate, outputFormat, out, outputWrite, truncate } from '../output.js';
 import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
+import { sortMemories } from './list.js';
 
 /** Render a list of recall memories to stdout (shared between normal and watch mode) */
 function renderMemories(memories: any[], opts: { showId?: boolean } = {}) {
@@ -106,14 +107,17 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   if (outputJson) {
     if (hasDateFilter) {
       let filtered = filterByDateRange(result.memories || [], 'created_at', sinceDate, untilDate);
+      filtered = sortMemories(filtered, opts);
       if (trimLimit) filtered = filtered.slice(0, trimLimit);
       out({ ...result, memories: filtered });
     } else {
-      out(result);
+      let memories = sortMemories(result.memories || [], opts);
+      out({ ...result, memories });
     }
   } else if (outputFormat === 'csv' || outputFormat === 'tsv' || outputFormat === 'yaml') {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    memories = sortMemories(memories, opts);
     if (trimLimit) memories = memories.slice(0, trimLimit);
     const rows = memories.map((m: any) => ({
       id: m.id || '',
@@ -128,6 +132,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else if (opts.raw) {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    memories = sortMemories(memories, opts);
     if (trimLimit) memories = memories.slice(0, trimLimit);
     for (const mem of memories) {
       outputWrite(mem.content);
@@ -135,6 +140,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
   } else {
     let memories = result.memories || [];
     memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+    memories = sortMemories(memories, opts);
     if (trimLimit) memories = memories.slice(0, trimLimit);
     renderMemories(memories, { showId: true });
   }

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -37,7 +37,7 @@ export async function cmdStoreBatch(opts: ParsedArgs, lines: string[]) {
       mem.importance = validateImportance(opts.importance);
     if (opts.tags && !mem.metadata)
       mem.metadata = { tags: opts.tags.split(',').map((t: string) => t.trim()) };
-    if (opts.namespace && !mem.namespace) mem.namespace = opts.namespace;
+    if (opts.namespace && mem.namespace === undefined) mem.namespace = opts.namespace;
     if (opts.memoryType && !mem.memory_type) mem.memory_type = opts.memoryType;
     if (opts.immutable !== undefined && mem.immutable === undefined) mem.immutable = opts.immutable !== 'false' && opts.immutable !== false;
     if (opts.pinned !== undefined && mem.pinned === undefined) mem.pinned = opts.pinned !== 'false' && opts.pinned !== false;

--- a/src/help.ts
+++ b/src/help.ts
@@ -75,6 +75,8 @@ Options:
   --tags <tag1,tag2>     Filter by tags
   --since <date>         Only memories created after date (ISO 8601 or 1h/7d/2w/1mo/1y)
   --until <date>         Only memories created before date
+  --sort-by <field>      Sort by field (id, importance, created, updated, similarity)
+  --reverse              Reverse sort order
   --raw                  Output content only (for piping)
   --watch                Watch for changes (continuous polling)
   --watch-interval <ms>  Polling interval (default: 5000)`,

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1484,6 +1484,37 @@ describe('store batch flags', () => {
     expect(parsed.ids).toEqual(['id-aaa', 'id-bbb']);
     expect(parsed.stored).toBe(2);
   });
+
+  test('batch respects explicit empty-string namespace per item (#189)', async () => {
+    const { cmdStoreBatch } = await import('../src/commands/store.js');
+    mockFetchResponse = { stored: 2 };
+    allFetches.length = 0;
+
+    await cmdStoreBatch(
+      { _: [], namespace: 'fallback', quiet: true } as any,
+      ['[{"content":"hello","namespace":""},{"content":"world","namespace":"project1"}]']
+    );
+
+    const body = JSON.parse(allFetches.find(f => f.url.includes('/store/batch'))?.options?.body || '{}');
+    // Item with explicit empty namespace should keep it, not be overridden by fallback
+    expect(body.memories[0].namespace).toBe('');
+    // Item with explicit namespace should keep it
+    expect(body.memories[1].namespace).toBe('project1');
+  });
+
+  test('batch applies global --namespace when item has no namespace field (#189)', async () => {
+    const { cmdStoreBatch } = await import('../src/commands/store.js');
+    mockFetchResponse = { stored: 1 };
+    allFetches.length = 0;
+
+    await cmdStoreBatch(
+      { _: [], namespace: 'fallback', quiet: true } as any,
+      ['[{"content":"no ns field"}]']
+    );
+
+    const body = JSON.parse(allFetches.find(f => f.url.includes('/store/batch'))?.options?.body || '{}');
+    expect(body.memories[0].namespace).toBe('fallback');
+  });
 });
 
 describe('list tags filter', () => {


### PR DESCRIPTION
## Changes

### Bug Fix: `store --batch` namespace override (#189)
- Changed `!mem.namespace` to `mem.namespace !== undefined` so explicit empty-string namespace is preserved
- Previously, `{"content":"hello","namespace":""}` with `--namespace fallback` would override to `fallback`

### Bug Fix: `recall --sort-by` silently ignored (#192)
- Imported and applied `sortMemories()` in all output branches of `cmdRecall`
- Added `--sort-by` and `--reverse` to recall help text
- Recall now supports sorting by id, importance, created, updated, similarity

### Closed
- #188: Already fixed in main (`cmdExport` already calls `sortMemories`)

### Tests
- 2 new tests for batch namespace behavior
- All 583 tests pass

Fixes #189
Fixes #192