### PR TITLE
fix: apply --sort-by in list command JSON output

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -201,10 +201,12 @@ export async function cmdList(opts: ParsedArgs) {
   if (outputJson) {
     if (hasDateFilter) {
       let filtered = filterByDateRange(result.memories || result.data || [], 'created_at', sinceDate, untilDate);
+      filtered = sortMemories(filtered, opts);
       if (trimLimit) filtered = filtered.slice(0, trimLimit);
       out({ ...result, memories: filtered, total: filtered.length });
     } else {
-      out(result);
+      let memories = sortMemories(result.memories || result.data || [], opts);
+      out({ ...result, memories });
     }
   } else if (opts.raw) {
     let memories = result.memories || result.data || [];


### PR DESCRIPTION
Fixes #195

The `list` command was silently ignoring `--sort-by` when `--json` was used.

In the JSON output path, memories were passed through without calling `sortMemories()`, while all other output formats (table, csv, yaml, raw) correctly applied client-side sorting.

**Changes:**
- Apply `sortMemories()` in both JSON output paths (with and without date filters)

**Testing:**
- All 610 existing tests pass
- Build succeeds