### PR TITLE
fix: recall --watch sorting + improve auth error message

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,8 +12,8 @@ import { PRIVATE_KEY } from './config.js';
 
 function ensureAuth() {
   if (!PRIVATE_KEY) {
-    console.error(`${c.red}Error:${c.reset} MEMOCLAW_PRIVATE_KEY environment variable required`);
-    console.error(`${c.dim}Set it with: export MEMOCLAW_PRIVATE_KEY=0x...${c.reset}`);
+    console.error(`${c.red}Error:${c.reset} No wallet configured.`);
+    console.error(`${c.dim}Run \`memoclaw init\` to create a wallet, or set MEMOCLAW_PRIVATE_KEY=0x...${c.reset}`);
     process.exit(1);
   }
 }

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -65,6 +65,7 @@ export async function cmdRecall(query: string, opts: ParsedArgs) {
         const result = await request('POST', '/v1/recall', body) as any;
         let memories = result.memories || [];
         memories = filterByDateRange(memories, 'created_at', sinceDate, untilDate);
+        memories = sortMemories(memories, opts);
         if (watchTrimLimit) memories = memories.slice(0, watchTrimLimit);
         const fingerprint = memories.map((m: any) => `${m.id}:${m.updated_at || ''}`).join('|');
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3572,3 +3572,30 @@ describe('cmdSnapshot', () => {
     expect(parsed.snapshots).toBeDefined();
   });
 });
+
+// ─── #197: recall --watch should apply --sort-by sorting ──────────────────────
+
+describe('recall watch mode sorting (#197)', () => {
+  test('recall watch code path includes sortMemories call', async () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/commands/recall.ts', 'utf-8');
+    // Extract the watch mode block: from "if (opts.watch)" to the end of
+    // the outer while loop. The non-watch path starts with a separate
+    // `const result = await request(...)` that is NOT indented inside the if.
+    const watchBlock = source.split('if (opts.watch)')[1]?.split('\n  const result')[0];
+    expect(watchBlock).toBeDefined();
+    // sortMemories must appear in the watch loop (not just the non-watch path)
+    expect(watchBlock).toContain('sortMemories');
+  });
+});
+
+// ─── #199: auth error should suggest memoclaw init ────────────────────────────
+
+describe('auth error message (#199)', () => {
+  test('auth.ts error message mentions memoclaw init', async () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/auth.ts', 'utf-8');
+    expect(source).toContain('memoclaw init');
+    expect(source).toContain('No wallet configured');
+  });
+});


### PR DESCRIPTION
## Changes

### Bug Fix: recall --watch ignores --sort-by (#197)
`memoclaw recall --watch --sort-by importance` was not sorting results in watch mode. Added `sortMemories(memories, opts)` call in the watch loop to match non-watch behavior.

### Enhancement: Auth error suggests `memoclaw init` (#199)
The auth error message now suggests `memoclaw init` as the primary onboarding path, rather than only mentioning the `MEMOCLAW_PRIVATE_KEY` env var. This improves the first-run experience.

### Tests
- Source-level test verifying `sortMemories` is called in recall watch code path
- Source-level test verifying auth error mentions `memoclaw init`

All 612 tests pass.

Fixes #197
Fixes #199