### PR TITLE
enhance: parallel alias list + import --dry-run

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -11,7 +11,7 @@ export interface ParsedArgs {
 export const BOOLEAN_FLAGS = new Set([
   'help', 'version', 'raw', 'json', 'quiet', 'dryRun', 'verbose', 'noColor',
   'force', 'count', 'wide', 'pretty', 'watch', 'interactive', 'yes', 'reverse',
-  'noTruncate', 'batch', 'idOnly', 'noRetry', 'all', 'check',
+  'noTruncate', 'batch', 'idOnly', 'noRetry', 'all', 'check', 'noPreview',
 ]);
 
 /** Short flag aliases */

--- a/src/commands/alias.ts
+++ b/src/commands/alias.ts
@@ -54,18 +54,40 @@ export async function cmdAlias(subcmd: string | undefined, rest: string[], opts:
         return;
       }
 
-      // Optionally fetch memory previews (best-effort, don't fail if API is down)
+      // Fetch memory previews in parallel (best-effort, skip with --no-preview)
       const rows: Record<string, any>[] = [];
-      for (const [name, id] of entries) {
-        let preview = '';
-        try {
-          const mem = await request('GET', `/v1/memories/${id}`) as any;
-          const content = mem?.memory?.content || mem?.content || '';
-          preview = content.length > 50 ? content.slice(0, 47) + '...' : content;
-        } catch {
-          preview = `${c.dim}(unavailable)${c.reset}`;
+      if (opts.noPreview) {
+        for (const [name, id] of entries) {
+          rows.push({ alias: `@${name}`, id: id.slice(0, 12) + '…', preview: `${c.dim}—${c.reset}` });
         }
-        rows.push({ alias: `@${name}`, id: id.slice(0, 12) + '…', preview });
+      } else {
+        const CONCURRENCY = 5;
+        const previews = new Map<string, string>();
+
+        for (let i = 0; i < entries.length; i += CONCURRENCY) {
+          const batch = entries.slice(i, i + CONCURRENCY);
+          const results = await Promise.allSettled(
+            batch.map(async ([, id]) => {
+              const mem = await request('GET', `/v1/memories/${id}`) as any;
+              const content = mem?.memory?.content || mem?.content || '';
+              return { id, content };
+            })
+          );
+          for (let j = 0; j < batch.length; j++) {
+            const [, id] = batch[j];
+            const r = results[j];
+            if (r.status === 'fulfilled') {
+              const content = r.value.content;
+              previews.set(id, content.length > 50 ? content.slice(0, 47) + '...' : content);
+            } else {
+              previews.set(id, `${c.dim}(unavailable)${c.reset}`);
+            }
+          }
+        }
+
+        for (const [name, id] of entries) {
+          rows.push({ alias: `@${name}`, id: id.slice(0, 12) + '…', preview: previews.get(id) || '' });
+        }
       }
 
       table(rows, [

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -104,6 +104,34 @@ export async function cmdImport(opts: ParsedArgs) {
   const memories = data.memories || data;
   if (!Array.isArray(memories)) throw new Error('Invalid format: expected { memories: [...] } or [...]');
 
+  // --dry-run: validate and report without calling API
+  if (opts.dryRun) {
+    const MAX_CONTENT_LENGTH = 8192;
+    let valid = 0;
+    let errors: string[] = [];
+    for (let i = 0; i < memories.length; i++) {
+      const mem = memories[i];
+      if (!mem.content || typeof mem.content !== 'string') {
+        errors.push(`Memory ${i}: missing or non-string content`);
+      } else if (mem.content.length > MAX_CONTENT_LENGTH) {
+        errors.push(`Memory ${i}: content too long (${mem.content.length} chars, max ${MAX_CONTENT_LENGTH})`);
+      } else {
+        valid++;
+      }
+    }
+    const batchCount = Math.ceil(valid / 100);
+    if (outputJson) {
+      out({ dryRun: true, total: memories.length, valid, errors: errors.length, errorDetails: errors.slice(0, 20), estimatedBatches: batchCount });
+    } else {
+      if (errors.length > 0) {
+        for (const e of errors.slice(0, 10)) warn(e);
+        if (errors.length > 10) warn(`... and ${errors.length - 10} more errors`);
+      }
+      success(`Dry run: ${valid} memories would be imported in ~${batchCount} batch${batchCount !== 1 ? 'es' : ''} (${errors.length} validation error${errors.length !== 1 ? 's' : ''})`);
+    }
+    return;
+  }
+
   const BATCH_SIZE = 100; // API max per batch request
   const concurrency = Math.max(1, parseInt(opts.concurrency || '1'));
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3599,3 +3599,95 @@ describe('auth error message (#199)', () => {
     expect(source).toContain('No wallet configured');
   });
 });
+
+// ─── #198: alias list parallel fetches + --no-preview ─────────────────────────
+
+describe('alias list performance (#198)', () => {
+  test('alias list source uses Promise.allSettled for parallel fetches', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/commands/alias.ts', 'utf-8');
+    expect(source).toContain('Promise.allSettled');
+    expect(source).toContain('CONCURRENCY');
+  });
+
+  test('alias list source supports --no-preview flag', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/commands/alias.ts', 'utf-8');
+    expect(source).toContain('noPreview');
+  });
+
+  test('--no-preview skips API calls', async () => {
+    saveAliases({ 'test-np': 'id-np-123' });
+    allFetches.length = 0;
+    captureConsole();
+    await cmdAlias('list', [], { _: [], noPreview: true } as any);
+    restoreConsole();
+    // Should not have fetched any memory previews
+    const previewFetches = allFetches.filter(f => f.url.includes('/v1/memories/'));
+    expect(previewFetches.length).toBe(0);
+    expect(consoleOutput.join('\n')).toContain('@test-np');
+  });
+
+  test('noPreview is in BOOLEAN_FLAGS', () => {
+    const { BOOLEAN_FLAGS } = require('../src/args.js');
+    expect(BOOLEAN_FLAGS.has('noPreview')).toBe(true);
+  });
+});
+
+// ─── #200: import --dry-run ──────────────────────────────────────────────────
+
+describe('import --dry-run (#200)', () => {
+  test('dry-run validates without calling API', async () => {
+    const tmpFile = path.join(os.tmpdir(), `memoclaw-import-dryrun-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({
+      memories: [
+        { content: 'memory one' },
+        { content: 'memory two' },
+        { content: 'memory three' },
+      ]
+    }));
+
+    allFetches.length = 0;
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdImport({ _: [], file: tmpFile, dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    // No API calls should have been made
+    const storeFetches = allFetches.filter(f => f.url.includes('/v1/store'));
+    expect(storeFetches.length).toBe(0);
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.valid).toBe(3);
+    expect(parsed.errors).toBe(0);
+    expect(parsed.estimatedBatches).toBe(1);
+
+    fs.unlinkSync(tmpFile);
+  });
+
+  test('dry-run reports validation errors', async () => {
+    const tmpFile = path.join(os.tmpdir(), `memoclaw-import-dryrun-err-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({
+      memories: [
+        { content: 'valid memory' },
+        { content: 123 },  // non-string
+        { notContent: 'missing content field' },  // missing content
+      ]
+    }));
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdImport({ _: [], file: tmpFile, dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.valid).toBe(1);
+    expect(parsed.errors).toBe(2);
+
+    fs.unlinkSync(tmpFile);
+  });
+});


### PR DESCRIPTION
## Changes

### Enhancement: alias list parallel fetches (#198)
`memoclaw alias list` was fetching memory previews sequentially (O(N) API calls). Now uses `Promise.allSettled()` with a concurrency limit of 5 to fetch in parallel, reducing wall time from O(N) to O(N/5).

Also adds `--no-preview` flag to skip preview fetches entirely for instant listing.

### Enhancement: import --dry-run (#200)
Adds `--dry-run` flag to `memoclaw import` that validates all memories without calling the API:
- Checks content exists and is a string
- Validates content length (max 8192 chars)
- Reports count, validation errors, and estimated batch count
- Supports both JSON and text output modes

### Tests
- 6 new tests: parallel fetch source verification, --no-preview skips API, noPreview in BOOLEAN_FLAGS, dry-run validation (valid + invalid data)

All 618 tests pass.

Fixes #198
Fixes #200