### PR TITLE
enhance: move command supports filter-based bulk selection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,9 @@ try {
         const stdin = await readStdin();
         if (stdin) ids = stdin.split(/[\n,\s]+/).map(s => s.trim()).filter(Boolean);
       }
-      if (ids.length === 0) throw new Error('Memory ID(s) required. Usage: memoclaw move <id> --namespace <target>');
+      // Allow empty ids when filter flags are present (resolved inside cmdMove)
+      const hasFilters = !!(args.fromNamespace || args.tags || args.since || args.until);
+      if (ids.length === 0 && !hasFilters) throw new Error('Memory ID(s) or filter flags required. Usage: memoclaw move <id> --namespace <target>\n  Or: memoclaw move --from-namespace <src> --namespace <target>');
       await cmdMove(ids, args);
       break;
     }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -5,8 +5,9 @@
 import type { ParsedArgs } from '../args.js';
 import { request } from '../http.js';
 import { c } from '../colors.js';
-import { outputJson, outputFormat, out, outputWrite, success, readStdin } from '../output.js';
+import { outputJson, outputQuiet, outputFormat, out, outputWrite, success, progressBar, readStdin } from '../output.js';
 import { validateContentLength, validateImportance, warnIfBooleanImportance } from '../validate.js';
+import { parseDate, filterByDateRange } from '../dates.js';
 import { readFileContent } from './store.js';
 
 export async function cmdGet(id: string, opts?: ParsedArgs) {
@@ -242,15 +243,74 @@ export async function cmdMove(ids: string[], opts: ParsedArgs) {
     throw new Error('Target namespace required. Usage: memoclaw move <id> --namespace <target>');
   }
 
+  // If no explicit IDs but filter flags provided, resolve IDs from filters
+  if (ids.length === 0 && (opts.fromNamespace || opts.tags || opts.since || opts.until)) {
+    ids = await resolveFilteredIds(opts);
+    if (ids.length === 0) {
+      if (outputJson) {
+        out({ moved: 0, namespace: opts.namespace, ids: [] });
+      } else {
+        success(`No memories matched the filter criteria`);
+      }
+      return;
+    }
+    if (!outputQuiet) {
+      process.stderr.write(`${c.dim}Found ${ids.length} matching memor${ids.length === 1 ? 'y' : 'ies'}${c.reset}\n`);
+    }
+  }
+
+  if (ids.length === 0) {
+    throw new Error('Memory ID(s) or filter flags required. Usage: memoclaw move <id> --namespace <target>\n  Or: memoclaw move --from-namespace <src> --namespace <target>');
+  }
+
   let moved = 0;
   for (const id of ids) {
     await request('PATCH', `/v1/memories/${id}`, { namespace: opts.namespace });
     moved++;
+    if (!outputQuiet && ids.length > 10) {
+      process.stderr.write(`\r  ${progressBar(moved, ids.length)}`);
+    }
   }
+  if (!outputQuiet && ids.length > 10) process.stderr.write('\n');
 
   if (outputJson) {
     out({ moved, namespace: opts.namespace, ids });
   } else {
     success(`Moved ${c.cyan}${moved}${c.reset} memor${moved === 1 ? 'y' : 'ies'} to namespace ${c.cyan}${opts.namespace}${c.reset}`);
   }
+}
+
+/** Fetch memory IDs matching filter flags (--from-namespace, --tags, --since, --until) */
+async function resolveFilteredIds(opts: ParsedArgs): Promise<string[]> {
+  const params = new URLSearchParams({ limit: '1000' });
+  if (opts.fromNamespace) params.set('namespace', opts.fromNamespace);
+  if (opts.tags) params.set('tags', opts.tags);
+
+  const sinceDate = opts.since ? parseDate(opts.since) : null;
+  const untilDate = opts.until ? parseDate(opts.until) : null;
+  if ((opts.since && !sinceDate) || (opts.until && !untilDate)) {
+    throw new Error('Invalid date format. Use ISO 8601 (2025-01-01) or relative shorthand (1h, 7d, 2w, 1mo, 1y).');
+  }
+
+  const allIds: string[] = [];
+  let offset = 0;
+
+  while (true) {
+    params.set('offset', String(offset));
+    const result = await request('GET', `/v1/memories?${params}`) as any;
+    const memories = result.memories || result.data || [];
+    if (memories.length === 0) break;
+
+    const filtered = (sinceDate || untilDate)
+      ? filterByDateRange(memories, 'created_at', sinceDate, untilDate)
+      : memories;
+    allIds.push(...filtered.map((m: any) => m.id));
+
+    if (memories.length < 1000) break;
+    offset += 1000;
+    if (!outputQuiet) process.stderr.write(`\r  ${c.dim}Scanning... ${allIds.length} matching${c.reset}`);
+  }
+  if (!outputQuiet && allIds.length > 0) process.stderr.write('\r' + ' '.repeat(60) + '\r');
+
+  return allIds;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -278,17 +278,24 @@ Options:
   --memory-type <type>   Override memory type
   --id-only              Print only the new memory ID (for scripting)`,
 
-      move: `${c.bold}memoclaw move${c.reset} <id> [<id2> ...] --namespace <target>
+      move: `${c.bold}memoclaw move${c.reset} [<id> ...] --namespace <target> [filters]
 
 Move one or more memories to a different namespace.
-IDs can be provided as arguments or piped via stdin.
+IDs can be provided as arguments, piped via stdin, or resolved from filter flags.
 
   ${c.dim}memoclaw move abc123 --namespace production${c.reset}
   ${c.dim}memoclaw move abc123 def456 --namespace archive${c.reset}
+  ${c.dim}memoclaw move --from-namespace old-project --namespace archive${c.reset}
+  ${c.dim}memoclaw move --tags stale --namespace archive${c.reset}
+  ${c.dim}memoclaw move --from-namespace staging --since 30d --namespace recent${c.reset}
   ${c.dim}memoclaw list --namespace staging --json | jq -r '.memories[].id' | memoclaw move --namespace production${c.reset}
 
 Options:
-  --namespace <name>     Target namespace (required)`,
+  --namespace <name>        Target namespace (required)
+  --from-namespace <name>   Select memories from this namespace
+  --tags <t1,t2>            Select memories matching these tags
+  --since <date>            Select memories created after date (ISO 8601 or relative: 1h, 7d, 2w, 1mo, 1y)
+  --until <date>            Select memories created before date`,
 
       'bulk-delete': `${c.bold}memoclaw bulk-delete${c.reset} <id1> <id2> ...
 
@@ -600,7 +607,7 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}edit${c.reset} <id>             Edit a memory in $EDITOR
   ${c.cyan}watch${c.reset}                  Watch for new memories in real-time
   ${c.cyan}copy${c.reset} <id>             Duplicate a memory
-  ${c.cyan}move${c.reset} <id> --namespace  Move memory to another namespace
+  ${c.cyan}move${c.reset} [id] --namespace  Move memories to another namespace (supports filters)
   ${c.cyan}ingest${c.reset}                 Ingest raw text into memories
   ${c.cyan}extract${c.reset} "text"         Extract memories from text
   ${c.cyan}context${c.reset} "query"        Get GPT-powered contextual summary ($0.01/call)

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3691,3 +3691,77 @@ describe('import --dry-run (#200)', () => {
     fs.unlinkSync(tmpFile);
   });
 });
+
+// ─── #201: move command filter-based bulk selection ───────────────────────────
+
+describe('move filter-based bulk selection (#201)', () => {
+  test('move source supports --from-namespace filter', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/commands/memory.ts', 'utf-8');
+    expect(source).toContain('fromNamespace');
+    expect(source).toContain('resolveFilteredIds');
+  });
+
+  test('move with --from-namespace fetches and moves matching memories', async () => {
+    // First call returns memories from source namespace, subsequent calls are PATCH moves
+    let callCount = 0;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      callCount++;
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/v1/memories?') && (!init || init.method === 'GET' || !init.method)) {
+        return new Response(JSON.stringify({
+          memories: [
+            { id: 'filter-1', content: 'mem1', created_at: new Date().toISOString() },
+            { id: 'filter-2', content: 'mem2', created_at: new Date().toISOString() },
+          ],
+          total: 2,
+        }), { status: 200 });
+      }
+      // PATCH calls for move
+      return new Response(JSON.stringify({ updated: true }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'archive', fromNamespace: 'old-project' } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(2);
+    expect(parsed.namespace).toBe('archive');
+
+    // Restore mock
+    setupMockFetch();
+  });
+
+  test('move with filters but no matches returns 0', async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ memories: [], total: 0 }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'archive', fromNamespace: 'empty-ns' } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(0);
+
+    setupMockFetch();
+  });
+
+  test('move without ids or filters throws', async () => {
+    await expect(
+      cmdMove([], { _: ['move'], namespace: 'target' } as any)
+    ).rejects.toThrow('filter flags required');
+  });
+
+  test('cli.ts allows move without ids when filter flags present', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/cli.ts', 'utf-8');
+    expect(source).toContain('hasFilters');
+    expect(source).toContain('fromNamespace');
+  });
+});


### PR DESCRIPTION
## Summary

Adds filter-based bulk selection to the `move` command, so users can move memories by criteria instead of requiring explicit IDs.

### New flags:
- `--from-namespace <name>` — select memories from a source namespace
- `--tags <t1,t2>` — select memories matching tags  
- `--since <date>` — created after date (ISO 8601 or relative: 1h, 7d, 2w, 1mo, 1y)
- `--until <date>` — created before date

### Examples:
```bash
memoclaw move --from-namespace old-project --namespace archive
memoclaw move --tags stale --namespace archive
memoclaw move --from-namespace staging --since 30d --namespace recent
```

### Changes:
- `src/commands/memory.ts`: Added `resolveFilteredIds()` + filter logic in `cmdMove`
- `src/cli.ts`: Allow empty IDs when filter flags present
- `src/help.ts`: Documented filter flags and examples
- `test/commands.test.ts`: 5 new tests

All 623 tests pass.

Fixes #201