### PR TITLE
enhance: add --dry-run and confirmation prompt for bulk move

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -244,17 +244,55 @@ export async function cmdMove(ids: string[], opts: ParsedArgs) {
   }
 
   // If no explicit IDs but filter flags provided, resolve IDs from filters
+  let resolvedMemories: Array<{ id: string; content?: string }> = [];
   if (ids.length === 0 && (opts.fromNamespace || opts.tags || opts.since || opts.until)) {
-    ids = await resolveFilteredIds(opts);
-    if (ids.length === 0) {
+    resolvedMemories = await resolveFilteredMemories(opts);
+    if (resolvedMemories.length === 0) {
       if (outputJson) {
-        out({ moved: 0, namespace: opts.namespace, ids: [] });
+        out(opts.dryRun ? { dry_run: true, would_move: 0, namespace: opts.namespace, ids: [] } : { moved: 0, namespace: opts.namespace, ids: [] });
       } else {
         success(`No memories matched the filter criteria`);
       }
       return;
     }
-    if (!outputQuiet) {
+    ids = resolvedMemories.map(m => m.id);
+
+    // --dry-run: show preview and exit without moving (#207)
+    if (opts.dryRun) {
+      if (outputJson) {
+        out({ dry_run: true, would_move: ids.length, namespace: opts.namespace, ids });
+      } else {
+        out(`Dry run — would move ${ids.length} memor${ids.length === 1 ? 'y' : 'ies'}:`);
+        for (const m of resolvedMemories) {
+          const preview = (m.content || '').slice(0, 60).replace(/\n/g, ' ');
+          outputWrite(`  ${c.cyan}${m.id.slice(0, 8)}${c.reset}  ${preview}${(m.content || '').length > 60 ? '…' : ''}`);
+        }
+      }
+      return;
+    }
+
+    // Confirmation prompt for bulk filter-based moves (#206)
+    // Skip when: --yes/-y, --json/-j, stdin is not a TTY, or only 1 match
+    const skipConfirm = opts.yes || outputJson || !process.stdin.isTTY || ids.length <= 1;
+    if (!skipConfirm) {
+      const sampleCount = Math.min(resolvedMemories.length, 5);
+      process.stderr.write(`\nFound ${c.bold}${ids.length}${c.reset} memories matching filters.\n`);
+      for (let i = 0; i < sampleCount; i++) {
+        const m = resolvedMemories[i];
+        const preview = (m.content || '').slice(0, 60).replace(/\n/g, ' ');
+        process.stderr.write(`  ${c.cyan}${m.id.slice(0, 8)}${c.reset}  ${preview}${(m.content || '').length > 60 ? '…' : ''}\n`);
+      }
+      if (ids.length > sampleCount) {
+        process.stderr.write(`  ${c.dim}... and ${ids.length - sampleCount} more${c.reset}\n`);
+      }
+      process.stderr.write(`\nMove all ${ids.length} to namespace ${c.cyan}${opts.namespace}${c.reset}? [y/N] `);
+
+      const confirmed = await askConfirm();
+      if (!confirmed) {
+        process.stderr.write('Aborted.\n');
+        return;
+      }
+    } else if (!outputQuiet && !outputJson) {
       process.stderr.write(`${c.dim}Found ${ids.length} matching memor${ids.length === 1 ? 'y' : 'ies'}${c.reset}\n`);
     }
   }
@@ -280,8 +318,20 @@ export async function cmdMove(ids: string[], opts: ParsedArgs) {
   }
 }
 
-/** Fetch memory IDs matching filter flags (--from-namespace, --tags, --since, --until) */
-async function resolveFilteredIds(opts: ParsedArgs): Promise<string[]> {
+/** Prompt user for y/N confirmation via readline */
+async function askConfirm(): Promise<boolean> {
+  const readline = await import('readline');
+  return new Promise(resolve => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    rl.question('', answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+/** Fetch memories matching filter flags (--from-namespace, --tags, --since, --until) */
+async function resolveFilteredMemories(opts: ParsedArgs): Promise<Array<{ id: string; content?: string }>> {
   const params = new URLSearchParams({ limit: '1000' });
   if (opts.fromNamespace) params.set('namespace', opts.fromNamespace);
   if (opts.tags) params.set('tags', opts.tags);
@@ -292,7 +342,7 @@ async function resolveFilteredIds(opts: ParsedArgs): Promise<string[]> {
     throw new Error('Invalid date format. Use ISO 8601 (2025-01-01) or relative shorthand (1h, 7d, 2w, 1mo, 1y).');
   }
 
-  const allIds: string[] = [];
+  const all: Array<{ id: string; content?: string }> = [];
   let offset = 0;
 
   while (true) {
@@ -304,13 +354,13 @@ async function resolveFilteredIds(opts: ParsedArgs): Promise<string[]> {
     const filtered = (sinceDate || untilDate)
       ? filterByDateRange(memories, 'created_at', sinceDate, untilDate)
       : memories;
-    allIds.push(...filtered.map((m: any) => m.id));
+    all.push(...filtered.map((m: any) => ({ id: m.id, content: m.content })));
 
     if (memories.length < 1000) break;
     offset += 1000;
-    if (!outputQuiet) process.stderr.write(`\r  ${c.dim}Scanning... ${allIds.length} matching${c.reset}`);
+    if (!outputQuiet) process.stderr.write(`\r  ${c.dim}Scanning... ${all.length} matching${c.reset}`);
   }
-  if (!outputQuiet && allIds.length > 0) process.stderr.write('\r' + ' '.repeat(60) + '\r');
+  if (!outputQuiet && all.length > 0) process.stderr.write('\r' + ' '.repeat(60) + '\r');
 
-  return allIds;
+  return all;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -288,6 +288,8 @@ IDs can be provided as arguments, piped via stdin, or resolved from filter flags
   ${c.dim}memoclaw move --from-namespace old-project --namespace archive${c.reset}
   ${c.dim}memoclaw move --tags stale --namespace archive${c.reset}
   ${c.dim}memoclaw move --from-namespace staging --since 30d --namespace recent${c.reset}
+  ${c.dim}memoclaw move --from-namespace staging --namespace prod --dry-run${c.reset}
+  ${c.dim}memoclaw move --from-namespace old --namespace archive --yes${c.reset}
   ${c.dim}memoclaw list --namespace staging --json | jq -r '.memories[].id' | memoclaw move --namespace production${c.reset}
 
 Options:
@@ -295,7 +297,9 @@ Options:
   --from-namespace <name>   Select memories from this namespace
   --tags <t1,t2>            Select memories matching these tags
   --since <date>            Select memories created after date (ISO 8601 or relative: 1h, 7d, 2w, 1mo, 1y)
-  --until <date>            Select memories created before date`,
+  --until <date>            Select memories created before date
+  --dry-run, -d             Preview which memories would be moved without moving them
+  --yes, -y                 Skip confirmation prompt for bulk moves`,
 
       'bulk-delete': `${c.bold}memoclaw bulk-delete${c.reset} <id1> <id2> ...
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3699,7 +3699,7 @@ describe('move filter-based bulk selection (#201)', () => {
     const fs = require('fs');
     const source = fs.readFileSync('src/commands/memory.ts', 'utf-8');
     expect(source).toContain('fromNamespace');
-    expect(source).toContain('resolveFilteredIds');
+    expect(source).toContain('resolveFilteredMemories');
   });
 
   test('move with --from-namespace fetches and moves matching memories', async () => {
@@ -3763,5 +3763,161 @@ describe('move filter-based bulk selection (#201)', () => {
     const source = fs.readFileSync('src/cli.ts', 'utf-8');
     expect(source).toContain('hasFilters');
     expect(source).toContain('fromNamespace');
+  });
+});
+
+// ─── #207: move --dry-run ────────────────────────────────────────────────────
+
+describe('move --dry-run (#207)', () => {
+  test('--dry-run with --json returns preview without moving', async () => {
+    let patchCalled = false;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/v1/memories?') && (!init || init.method === 'GET' || !init.method)) {
+        return new Response(JSON.stringify({
+          memories: [
+            { id: 'dry-1', content: 'First memory content', created_at: new Date().toISOString() },
+            { id: 'dry-2', content: 'Second memory content', created_at: new Date().toISOString() },
+            { id: 'dry-3', content: 'Third memory content', created_at: new Date().toISOString() },
+          ],
+          total: 3,
+        }), { status: 200 });
+      }
+      patchCalled = true;
+      return new Response(JSON.stringify({ updated: true }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'archive', fromNamespace: 'staging', dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.would_move).toBe(3);
+    expect(parsed.namespace).toBe('archive');
+    expect(parsed.ids).toEqual(['dry-1', 'dry-2', 'dry-3']);
+    expect(patchCalled).toBe(false);
+
+    setupMockFetch();
+  });
+
+  test('--dry-run with no matches returns 0', async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ memories: [], total: 0 }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'archive', fromNamespace: 'empty', dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.would_move).toBe(0);
+
+    setupMockFetch();
+  });
+
+  test('help text includes --dry-run', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/help.ts', 'utf-8');
+    expect(source).toContain('--dry-run');
+    expect(source).toContain('Preview which memories would be moved');
+  });
+});
+
+// ─── #206: move confirmation prompt ──────────────────────────────────────────
+
+describe('move confirmation prompt (#206)', () => {
+  test('--yes skips confirmation and moves directly (json mode)', async () => {
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/v1/memories?') && (!init || init.method === 'GET' || !init.method)) {
+        return new Response(JSON.stringify({
+          memories: [
+            { id: 'yes-1', content: 'Memory one', created_at: new Date().toISOString() },
+            { id: 'yes-2', content: 'Memory two', created_at: new Date().toISOString() },
+            { id: 'yes-3', content: 'Memory three', created_at: new Date().toISOString() },
+          ],
+          total: 3,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ updated: true }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'prod', fromNamespace: 'staging', yes: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(3);
+    expect(parsed.namespace).toBe('prod');
+
+    setupMockFetch();
+  });
+
+  test('json mode skips confirmation', async () => {
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/v1/memories?') && (!init || init.method === 'GET' || !init.method)) {
+        return new Response(JSON.stringify({
+          memories: [
+            { id: 'json-1', content: 'Memory', created_at: new Date().toISOString() },
+            { id: 'json-2', content: 'Memory', created_at: new Date().toISOString() },
+          ],
+          total: 2,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ updated: true }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    // JSON mode should skip prompt automatically
+    await cmdMove([], { _: ['move'], namespace: 'prod', fromNamespace: 'staging' } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(2);
+
+    setupMockFetch();
+  });
+
+  test('single match skips confirmation', async () => {
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/v1/memories?') && (!init || init.method === 'GET' || !init.method)) {
+        return new Response(JSON.stringify({
+          memories: [{ id: 'solo-1', content: 'Only memory', created_at: new Date().toISOString() }],
+          total: 1,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ updated: true }), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove([], { _: ['move'], namespace: 'prod', fromNamespace: 'staging' } as any);
+    restoreConsole();
+    resetOutputState();
+
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.moved).toBe(1);
+
+    setupMockFetch();
+  });
+
+  test('source includes askConfirm function', () => {
+    const fs = require('fs');
+    const source = fs.readFileSync('src/commands/memory.ts', 'utf-8');
+    expect(source).toContain('askConfirm');
+    expect(source).toContain('skipConfirm');
+    expect(source).toContain('process.stdin.isTTY');
   });
 });


### PR DESCRIPTION
## Summary

Adds two safety features for filter-based bulk moves (introduced in #205):

### --dry-run / -d flag (#207)
Preview which memories would be moved without actually moving them:
```bash
memoclaw move --from-namespace staging --namespace prod --dry-run
# Dry run — would move 12 memories:
#   abc12345  User preference for dark mode...
#   def45678  Project deadline is March 15...
```

With `--json`:
```json
{"dry_run": true, "would_move": 12, "namespace": "prod", "ids": ["abc123", ...]}
```

### Confirmation prompt (#206)
Interactive confirmation showing count and sample before bulk moves:
```
Found 47 memories matching filters.
  abc12345  First memory content...
  def45678  Second memory content...
  ... and 45 more

Move all 47 to namespace 'archive'? [y/N]
```

Prompt is skipped when:
- `--yes` / `-y` flag is present
- `--json` / `-j` flag is present  
- stdin is not a TTY (piped context)
- Only 1 memory matches

### Changes
- Add `--dry-run` and `--yes` support to `cmdMove`
- Rename `resolveFilteredIds` → `resolveFilteredMemories` (returns content for previews)
- Add `askConfirm()` readline helper
- Update help text with new flags/examples
- Add tests for both features

Fixes #206
Fixes #207