### PR TITLE
enhance: snapshot restore --namespace and --dry-run (#209, #210)

### DIFF
--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -159,7 +159,7 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
 
     case 'restore': {
       const query = rest[0];
-      if (!query) throw new Error('Usage: memoclaw snapshot restore <name>');
+      if (!query) throw new Error('Usage: memoclaw snapshot restore <name> [--namespace <ns>] [--dry-run] [--yes]');
 
       const snapshot = findSnapshot(query);
       if (!snapshot) throw new Error(`Snapshot "${query}" not found. Run "memoclaw snapshot list" to see available snapshots.`);
@@ -170,6 +170,44 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
 
       if (memories.length === 0) {
         warn('Snapshot contains no memories');
+        return;
+      }
+
+      // --namespace override: remap all memories to a different namespace (#209)
+      const namespaceOverride = opts.namespace || undefined;
+
+      // --dry-run: preview what would be restored without importing (#210)
+      if (opts.dryRun) {
+        if (outputJson) {
+          const sample = memories.slice(0, 10).map((m: any) => ({
+            id: m.id,
+            content: (m.content || '').slice(0, 80),
+            namespace: namespaceOverride || m.namespace || null,
+          }));
+          out({
+            dry_run: true,
+            would_restore: memories.length,
+            snapshot: snapshot.name,
+            namespace: namespaceOverride || snapshot.namespace || null,
+            sample,
+          });
+        } else {
+          const nsLabel = namespaceOverride
+            ? ` to namespace "${c.cyan}${namespaceOverride}${c.reset}"`
+            : '';
+          out(`Dry run — would restore ${memories.length} memor${memories.length === 1 ? 'y' : 'ies'} from "${c.cyan}${snapshot.name}${c.reset}"${nsLabel}:`);
+          const showCount = Math.min(memories.length, 10);
+          for (let i = 0; i < showCount; i++) {
+            const m = memories[i];
+            const preview = (m.content || '').slice(0, 60).replace(/\n/g, ' ');
+            const ns = namespaceOverride || m.namespace || '';
+            const nsTag = ns ? ` ${c.dim}(${ns})${c.reset}` : '';
+            outputWrite(`  ${c.cyan}${(m.id || '').slice(0, 8)}${c.reset}  ${preview}${(m.content || '').length > 60 ? '…' : ''}${nsTag}`);
+          }
+          if (memories.length > showCount) {
+            outputWrite(`  ${c.dim}... and ${memories.length - showCount} more${c.reset}`);
+          }
+        }
         return;
       }
 
@@ -184,7 +222,8 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
           const entry: Record<string, any> = { content: mem.content };
           if (mem.importance !== undefined) entry.importance = mem.importance;
           if (mem.metadata) entry.metadata = mem.metadata;
-          if (mem.namespace) entry.namespace = mem.namespace;
+          // Use namespace override if provided, otherwise original namespace (#209)
+          entry.namespace = namespaceOverride || mem.namespace || undefined;
           if (mem.memory_type) entry.memory_type = mem.memory_type;
           if (mem.session_id) entry.session_id = mem.session_id;
           if (mem.agent_id) entry.agent_id = mem.agent_id;
@@ -204,7 +243,7 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
               const body: Record<string, any> = { content: mem.content };
               if (mem.importance !== undefined) body.importance = mem.importance;
               if (mem.metadata) body.metadata = mem.metadata;
-              if (mem.namespace) body.namespace = mem.namespace;
+              body.namespace = namespaceOverride || mem.namespace || undefined;
               await request('POST', '/v1/store', body);
               imported++;
             } catch {
@@ -220,10 +259,18 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
 
       if (!outputQuiet) process.stderr.write('\n');
 
+      const nsInfo = namespaceOverride ? `, namespace: "${namespaceOverride}"` : '';
       if (outputJson) {
-        out({ restored: imported, failed, total: memories.length, snapshot: snapshot.name });
+        out({
+          restored: imported,
+          failed,
+          total: memories.length,
+          snapshot: snapshot.name,
+          ...(namespaceOverride ? { namespace: namespaceOverride } : {}),
+        });
       } else {
-        success(`Restored ${imported}/${memories.length} memories from "${c.cyan}${snapshot.name}${c.reset}"${failed ? ` (${c.red}${failed} failed${c.reset})` : ''}`);
+        const nsMsg = namespaceOverride ? ` → namespace "${c.cyan}${namespaceOverride}${c.reset}"` : '';
+        success(`Restored ${imported}/${memories.length} memories from "${c.cyan}${snapshot.name}${c.reset}"${nsMsg}${failed ? ` (${c.red}${failed} failed${c.reset})` : ''}`);
       }
       break;
     }
@@ -248,6 +295,6 @@ export async function cmdSnapshot(subcmd: string | undefined, rest: string[], op
     }
 
     default:
-      throw new Error(`Usage: memoclaw snapshot <create|list|restore|delete> [args]\n\n  create [--name <label>] [--namespace <ns>]   Create a snapshot\n  list                                          List all snapshots\n  restore <name>                                Restore from snapshot\n  delete <name>                                 Delete a snapshot`);
+      throw new Error(`Usage: memoclaw snapshot <create|list|restore|delete> [args]\n\n  create [--name <label>] [--namespace <ns>]           Create a snapshot\n  list                                                  List all snapshots\n  restore <name> [--namespace <ns>] [--dry-run]         Restore from snapshot\n  delete <name>                                         Delete a snapshot`);
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -552,13 +552,19 @@ operations like purge or consolidate.
 Subcommands:
   create [--name <label>] [--namespace <ns>]   Create a snapshot
   list                                          List all snapshots
-  restore <name>                                Restore from a snapshot
+  restore <name> [--namespace <ns>] [--dry-run] Restore from a snapshot
   delete <name>                                 Delete a snapshot
+
+Restore flags:
+  --namespace <ns>   Remap all memories to a different namespace
+  --dry-run, -d      Preview what would be restored without importing
 
   ${c.dim}memoclaw snapshot create${c.reset}
   ${c.dim}memoclaw snapshot create --name before-purge --namespace project1${c.reset}
   ${c.dim}memoclaw snapshot list${c.reset}
   ${c.dim}memoclaw snapshot restore before-purge${c.reset}
+  ${c.dim}memoclaw snapshot restore before-purge --namespace staging${c.reset}
+  ${c.dim}memoclaw snapshot restore before-purge --dry-run${c.reset}
   ${c.dim}memoclaw snapshot delete before-purge${c.reset}
 
 Snapshots are stored locally at ~/.memoclaw/snapshots/.

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3571,6 +3571,109 @@ describe('cmdSnapshot', () => {
     const parsed = JSON.parse(consoleOutput.join(''));
     expect(parsed.snapshots).toBeDefined();
   });
+
+  test('restore --dry-run previews without importing (#210)', async () => {
+    // Create a snapshot first
+    mockFetchResponse = {
+      memories: [
+        { id: 'dry-1', content: 'first memory', importance: 0.5, namespace: 'proj1' },
+        { id: 'dry-2', content: 'second memory', importance: 0.8, namespace: 'proj1' },
+      ],
+      total: 2,
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSnapshot('create', [], { _: [], name: 'dryrun-test' } as any);
+    restoreConsole();
+
+    // Now restore with --dry-run
+    allFetches.length = 0;
+    captureConsole();
+    await cmdSnapshot('restore', ['dryrun-test'], { _: [], dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.would_restore).toBe(2);
+    expect(parsed.snapshot).toBe('dryrun-test');
+    expect(parsed.sample).toBeDefined();
+    expect(parsed.sample.length).toBe(2);
+    // Verify no batch import was called (dry run should not call store)
+    const storeCall = allFetches.find(f => f.url.includes('/v1/store'));
+    expect(storeCall).toBeUndefined();
+
+    // Cleanup
+    await cmdSnapshot('delete', ['dryrun-test'], { _: [] } as any);
+  });
+
+  test('restore --namespace remaps memories to different namespace (#209)', async () => {
+    // Create a snapshot
+    mockFetchResponse = {
+      memories: [
+        { id: 'ns-1', content: 'memory one', importance: 0.5, namespace: 'original' },
+        { id: 'ns-2', content: 'memory two', importance: 0.8, namespace: 'original' },
+      ],
+      total: 2,
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSnapshot('create', [], { _: [], name: 'ns-remap-test' } as any);
+    restoreConsole();
+
+    // Restore with --namespace override
+    mockFetchResponse = { stored: 2 };
+    allFetches.length = 0;
+    captureConsole();
+    await cmdSnapshot('restore', ['ns-remap-test'], { _: [], namespace: 'staging' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.restored).toBe(2);
+    expect(parsed.namespace).toBe('staging');
+
+    // Verify the batch body used the override namespace
+    const batchCall = allFetches.find(f => f.url.includes('/v1/store/batch'));
+    expect(batchCall).toBeDefined();
+    const body = JSON.parse(batchCall!.options.body);
+    for (const mem of body.memories) {
+      expect(mem.namespace).toBe('staging');
+    }
+
+    // Cleanup
+    await cmdSnapshot('delete', ['ns-remap-test'], { _: [] } as any);
+  });
+
+  test('restore --dry-run with --namespace shows override namespace (#209, #210)', async () => {
+    // Create a snapshot
+    mockFetchResponse = {
+      memories: [
+        { id: 'both-1', content: 'memory data', importance: 0.5, namespace: 'old-ns' },
+      ],
+      total: 1,
+    };
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdSnapshot('create', [], { _: [], name: 'both-flags-test' } as any);
+    restoreConsole();
+
+    // Restore with both --dry-run and --namespace
+    allFetches.length = 0;
+    captureConsole();
+    await cmdSnapshot('restore', ['both-flags-test'], { _: [], dryRun: true, namespace: 'new-ns' } as any);
+    restoreConsole();
+    resetOutputState();
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.would_restore).toBe(1);
+    expect(parsed.namespace).toBe('new-ns');
+    expect(parsed.sample[0].namespace).toBe('new-ns');
+    // No actual store call
+    const storeCall = allFetches.find(f => f.url.includes('/v1/store'));
+    expect(storeCall).toBeUndefined();
+
+    // Cleanup
+    await cmdSnapshot('delete', ['both-flags-test'], { _: [] } as any);
+  });
 });
 
 // ─── #197: recall --watch should apply --sort-by sorting ──────────────────────


### PR DESCRIPTION
## Summary

Adds two safety/convenience features for `snapshot restore`:

### --namespace flag (#209)
Remap all restored memories to a different namespace:
```bash
# Restore to same namespace (current behavior)
memoclaw snapshot restore before-purge

# Restore to different namespace (new behavior)
memoclaw snapshot restore before-purge --namespace staging
memoclaw snapshot restore before-purge --namespace project-v2
```

JSON output includes the namespace override:
```json
{"restored": 42, "failed": 0, "total": 42, "snapshot": "before-purge", "namespace": "staging"}
```

### --dry-run flag (#210)
Preview what would be restored without actually importing:
```bash
memoclaw snapshot restore before-purge --dry-run
# Dry run — would restore 47 memories from "before-purge":
#   abc12345  User preference for dark mode (proj1)
#   def45678  Project deadline is March 15 (proj1)
#   ... and 45 more
```

JSON output:
```json
{"dry_run": true, "would_restore": 47, "snapshot": "before-purge", "namespace": null, "sample": [...]}
```

Both flags compose:
```bash
memoclaw snapshot restore before-purge --namespace staging --dry-run
```

### Changes
- Add `--namespace` override to restore path (remaps all memories)
- Add `--dry-run` preview path (JSON + human-readable, no API calls)
- Update help text with new flags, descriptions, and examples
- Add 3 tests: dry-run only, namespace only, both combined

Fixes #209
Fixes #210