### PR TITLE
fix(cli): point search command at POST /v1/search

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -11,10 +11,27 @@ import { parseDate, filterByDateRange, overfetchLimit } from '../dates.js';
 import { sortMemories } from './list.js';
 
 export async function cmdSearch(query: string, opts: ParsedArgs) {
-  const params = new URLSearchParams({ q: query });
-  if (opts.limit != null && opts.limit !== true) params.set('limit', opts.limit);
-  if (opts.namespace) params.set('namespace', opts.namespace);
-  if (opts.tags) params.set('tags', opts.tags);
+  const body: Record<string, any> = { query };
+  let userLimit: number | undefined;
+
+  if (opts.limit != null && opts.limit !== true) {
+    const parsedLimit = parseInt(String(opts.limit));
+    if (!isNaN(parsedLimit) && parsedLimit > 0) {
+      userLimit = parsedLimit;
+      body.limit = parsedLimit;
+    }
+  }
+  if (opts.namespace) body.namespace = opts.namespace;
+  if (opts.memoryType) body.memory_type = opts.memoryType;
+  if (opts.sessionId) body.session_id = opts.sessionId;
+  if (opts.agentId) body.agent_id = opts.agentId;
+  if (opts.tags && opts.tags !== true) {
+    const tags = String(opts.tags)
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    if (tags.length > 0) body.tags = tags;
+  }
 
   // Parse date filters
   const sinceDate = opts.since ? parseDate(opts.since) : null;
@@ -27,15 +44,12 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
 
   // Over-fetch when date filters are active (#140)
   const hasDateFilter = !!(sinceDate || untilDate);
-  const userLimit = opts.limit != null && opts.limit !== true ? parseInt(opts.limit) : undefined;
   if (hasDateFilter) {
-    params.set('limit', String(overfetchLimit(userLimit)));
-    if (sinceDate) params.set('since', sinceDate.toISOString());
-    if (untilDate) params.set('until', untilDate.toISOString());
+    body.limit = overfetchLimit(userLimit);
   }
   const trimLimit = hasDateFilter && userLimit ? userLimit : undefined;
 
-  const result = await request('GET', `/v1/memories/search?${params}`) as any;
+  const result = await request('POST', '/v1/search', body) as any;
 
   if (outputJson) {
     if (hasDateFilter) {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -481,20 +481,19 @@ describe('cmdList', () => {
 // ─── Search ──────────────────────────────────────────────────────────────────
 
 describe('cmdSearch', () => {
-  test('sends GET /v1/memories/search with query', async () => {
+  test('sends POST /v1/search with query body', async () => {
     mockFetchResponse = { memories: [] };
     await cmdSearch('hello', { _: [] } as any);
-    expect(lastFetchUrl).toContain('/v1/memories/search');
-    expect(lastFetchUrl).toContain('q=hello');
+    expect(lastFetchUrl).toContain('/v1/search');
+    expect(lastFetchOptions.method).toBe('POST');
+    expect(getLastBody()).toMatchObject({ query: 'hello' });
     restoreConsole();
   });
 
-  test('includes limit, namespace, tags', async () => {
+  test('includes limit, namespace, tags, session and agent filters', async () => {
     mockFetchResponse = { memories: [] };
-    await cmdSearch('q', { _: [], limit: '5', namespace: 'ns', tags: 'a' } as any);
-    expect(lastFetchUrl).toContain('limit=5');
-    expect(lastFetchUrl).toContain('namespace=ns');
-    expect(lastFetchUrl).toContain('tags=a');
+    await cmdSearch('q', { _: [], limit: '5', namespace: 'ns', tags: 'a,b', sessionId: 'sess', agentId: 'agent', memoryType: 'decision' } as any);
+    expect(getLastBody()).toMatchObject({ query: 'q', limit: 5, namespace: 'ns', tags: ['a', 'b'], session_id: 'sess', agent_id: 'agent', memory_type: 'decision' });
     restoreConsole();
   });
 


### PR DESCRIPTION
## Summary
- send search requests to POST /v1/search instead of the removed GET /v1/memories/search route (which returned the Invalid memory ID format error)
- pass namespace, memory type, session/agent filters, and parsed tag arrays in the JSON body so the API can honor them
- keep client-side date filtering by over-fetching locally and trim after filtering
- refresh the command handler tests to assert the new request shape

Fixes anajuliabit/memoclaw-skill#74

## Testing
- bun test test/commands.test.ts --filter cmdSearch