### PR TITLE
fix: respect explicit false values for boolean flags

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -14,6 +14,18 @@ export const BOOLEAN_FLAGS = new Set([
   'noTruncate', 'batch', 'idOnly', 'noRetry', 'all', 'check', 'noPreview',
 ]);
 
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'y', 'on']);
+const FALSE_VALUES = new Set(['false', '0', 'no', 'n', 'off']);
+
+function normalizeBoolean(value: any): boolean | null {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return null;
+  const str = String(value).trim().toLowerCase();
+  if (TRUE_VALUES.has(str)) return true;
+  if (FALSE_VALUES.has(str)) return false;
+  return null;
+}
+
 /** Short flag aliases */
 const SHORT_FLAGS: Record<string, string> = {
   '-h': 'help',
@@ -61,7 +73,12 @@ export function parseArgs(args: string[]): ParsedArgs {
         const valuePart = arg.slice(eqIdx + 1);
         if (SHORT_FLAGS[flagPart]) {
           const key = SHORT_FLAGS[flagPart];
-          result[key] = valuePart;
+          if (BOOLEAN_FLAGS.has(key)) {
+            const boolVal = normalizeBoolean(valuePart);
+            result[key] = boolVal ?? true;
+          } else {
+            result[key] = valuePart;
+          }
           i++;
           continue;
         }
@@ -71,8 +88,15 @@ export function parseArgs(args: string[]): ParsedArgs {
       if (arg.length === 2 && SHORT_FLAGS[arg]) {
         const key = SHORT_FLAGS[arg];
         if (BOOLEAN_FLAGS.has(key)) {
-          result[key] = true;
-          i++;
+          const next = args[i + 1];
+          const boolVal = next !== undefined && !next.startsWith('--') ? normalizeBoolean(next) : null;
+          if (boolVal !== null) {
+            result[key] = boolVal;
+            i += 2;
+          } else {
+            result[key] = true;
+            i++;
+          }
         } else {
           const next = args[i + 1];
           // Match long-flag behavior: only reject values starting with '--'
@@ -99,7 +123,14 @@ export function parseArgs(args: string[]): ParsedArgs {
             const flag = `-${chars[ci]}`;
             const key = SHORT_FLAGS[flag];
             if (BOOLEAN_FLAGS.has(key)) {
-              result[key] = true;
+              const next = args[i + 1];
+              const boolVal = next !== undefined && !next.startsWith('--') ? normalizeBoolean(next) : null;
+              if (boolVal !== null && ci === chars.length - 1) {
+                result[key] = boolVal;
+                i++; // extra bump when value consumed
+              } else {
+                result[key] = true;
+              }
             } else if (ci === chars.length - 1) {
               // Last flag can take a value
               const next = args[i + 1];
@@ -141,11 +172,23 @@ export function parseArgs(args: string[]): ParsedArgs {
       }
 
       if (inlineValue !== undefined) {
-        result[key] = inlineValue;
+        if (BOOLEAN_FLAGS.has(key)) {
+          const boolVal = normalizeBoolean(inlineValue);
+          result[key] = boolVal ?? true;
+        } else {
+          result[key] = inlineValue;
+        }
         i++;
       } else if (BOOLEAN_FLAGS.has(key)) {
-        result[key] = true;
-        i++;
+        const next = args[i + 1];
+        const boolVal = next !== undefined && (!next.startsWith('--') || /^--?\d/.test(next)) ? normalizeBoolean(next) : null;
+        if (boolVal !== null) {
+          result[key] = boolVal;
+          i += 2;
+        } else {
+          result[key] = true;
+          i++;
+        }
       } else {
         const next = args[i + 1];
         // Allow negative numbers as values (e.g., --offset -1 is unlikely but --importance -0.5... well)

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -157,7 +157,7 @@ export async function cmdConsolidate(opts: ParsedArgs) {
   if (opts.namespace) body.namespace = opts.namespace;
   if (opts.minSimilarity != null && opts.minSimilarity !== true) body.min_similarity = parseFloat(opts.minSimilarity);
   if (opts.mode) body.mode = opts.mode;
-  if (opts.dryRun !== undefined) body.dry_run = true;
+  if (opts.dryRun === true || opts.dryRun === 'true') body.dry_run = true;
 
   const result = await request('POST', '/v1/memories/consolidate', body) as any;
   if (outputJson) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -94,6 +94,34 @@ describe('parseArgs', () => {
     expect(result.namespace).toBe('test');
   });
 
+  test('boolean flags accept --flag=false inline', () => {
+    const result = parseArgs(['--dry-run=false']);
+    expect(result.dryRun).toBe(false);
+  });
+
+  test('boolean flags accept explicit false value as next arg', () => {
+    const result = parseArgs(['--dry-run', 'false', 'restore']);
+    expect(result.dryRun).toBe(false);
+    expect(result._).toEqual(['restore']);
+  });
+
+  test('short boolean flags accept -d=false syntax', () => {
+    const result = parseArgs(['-d=false']);
+    expect(result.dryRun).toBe(false);
+  });
+
+  test('short boolean flags accept -d 0 syntax', () => {
+    const result = parseArgs(['-d', '0', 'run']);
+    expect(result.dryRun).toBe(false);
+    expect(result._).toEqual(['run']);
+  });
+
+  test('boolean flags treat --json=0 as false', () => {
+    const result = parseArgs(['--json=0', 'list']);
+    expect(result.json).toBe(false);
+    expect(result._).toEqual(['list']);
+  });
+
   test('handles flag without value at end', () => {
     const result = parseArgs(['--namespace']);
     expect(result.namespace).toBe(true);

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1051,6 +1051,14 @@ describe('cmdConsolidate', () => {
     restoreConsole();
   });
 
+  test('does not send dry_run when flag is explicitly false', async () => {
+    mockFetchResponse = { merged_count: 1 };
+    await cmdConsolidate({ _: [], dryRun: false } as any);
+    const body = getLastBody();
+    expect(body.dry_run).toBeUndefined();
+    restoreConsole();
+  });
+
   test('shows dry run info', async () => {
     mockFetchResponse = { merged_count: 3, clusters: [1, 2, 3] };
     await cmdConsolidate({ _: [], dryRun: true } as any);


### PR DESCRIPTION
## Summary
- normalize boolean-only flags so `--flag=false`, `--flag 0`, etc. become actual booleans for both long/short inline flags and when the value is provided as the next arg
- only send `dry_run` for consolidate when the flag is truly enabled
- cover the new parsing behavior + consolidate regression with unit tests

Fixes #213