### PR TITLE
fix: show default namespace label in list

### DIFF
--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -51,7 +51,10 @@ export async function cmdNamespace(subcmd: string, rest: string[], opts: ParsedA
     } else if (namespaces.length === 0) {
       outputWrite(`${c.dim}No namespaces found.${c.reset}`);
     } else {
-      table(namespaces.map(ns => ({ namespace: ns.name })), [{ key: 'namespace', label: 'NAMESPACE', width: 30 }]);
+      table(
+        namespaces.map(ns => ({ namespace: ns.name || '(default)' })),
+        [{ key: 'namespace', label: 'NAMESPACE', width: 30 }]
+      );
       outputWrite(`${c.dim}─ ${namespaces.length} namespace${namespaces.length !== 1 ? 's' : ''}${c.reset}`);
     }
   } else if (subcmd === 'stats') {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1196,6 +1196,14 @@ describe('cmdNamespace', () => {
     expect(parsed.count).toBe(2);
     restoreConsole();
   });
+
+  test('list shows (default) label for empty namespace', async () => {
+    mockFetchResponse = { namespaces: ['', 'proj'] };
+    await cmdNamespace('list', [], { _: [] } as any);
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('(default)');
+    restoreConsole();
+  });
 });
 
 // ─── Export ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- render (default) when namespace list receives an empty namespace string so the default namespace is visible in table output
- leave JSON output untouched (still returns an empty string for the default namespace)
- add a regression test that verifies the label appears whenever the API responds with an empty namespace name

Fixes #215.