### PR TITLE
chore(ci): unblock cli workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary\nEvery CLI workflow was stuck in the queue because the jobs targeted the `namespace-profile-default` label even though this repo no longer has Namespace runners. This PR switches the CI and publish workflows back to GitHub-hosted `ubuntu-latest` runners so tests and releases can run again.\n\nFixes #222.