### PR TITLE
fix: NaN guards for --limit parsing + --dry-run support for explicit move IDs

### DIFF
--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -13,7 +13,9 @@ export async function cmdHistory(id: string, opts?: ParsedArgs) {
   let history = result.history || [];
 
   // Apply --limit: show only the N most recent entries
-  const userLimit = opts?.limit != null && opts.limit !== true ? parseInt(opts.limit) : undefined;
+  const userLimit = opts?.limit != null && opts.limit !== true
+    ? (() => { const n = parseInt(String(opts.limit)); return !isNaN(n) && n > 0 ? n : undefined; })()
+    : undefined;
   if (userLimit != null && userLimit > 0) {
     history = history.slice(-userLimit);
   }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -301,6 +301,19 @@ export async function cmdMove(ids: string[], opts: ParsedArgs) {
     throw new Error('Memory ID(s) or filter flags required. Usage: memoclaw move <id> --namespace <target>\n  Or: memoclaw move --from-namespace <src> --namespace <target>');
   }
 
+  // --dry-run for explicit IDs (filter-based dry-run handled above)
+  if (opts.dryRun) {
+    if (outputJson) {
+      out({ dry_run: true, would_move: ids.length, namespace: opts.namespace, ids });
+    } else {
+      outputWrite(`Dry run — would move ${ids.length} memor${ids.length === 1 ? 'y' : 'ies'} to namespace ${c.cyan}${opts.namespace}${c.reset}:`);
+      for (const id of ids) {
+        outputWrite(`  ${c.cyan}${id.slice(0, 8)}…${c.reset}`);
+      }
+    }
+    return;
+  }
+
   let moved = 0;
   for (const id of ids) {
     await request('PATCH', `/v1/memories/${id}`, { namespace: opts.namespace });

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -28,7 +28,10 @@ function renderMemories(memories: any[], opts: { showId?: boolean } = {}) {
 
 export async function cmdRecall(query: string, opts: ParsedArgs) {
   const body: Record<string, any> = { query };
-  if (opts.limit != null && opts.limit !== true) body.limit = parseInt(opts.limit);
+  if (opts.limit != null && opts.limit !== true) {
+    const parsedLimit = parseInt(String(opts.limit));
+    if (!isNaN(parsedLimit) && parsedLimit > 0) body.limit = parsedLimit;
+  }
   if (opts.minSimilarity != null && opts.minSimilarity !== true) body.min_similarity = parseFloat(opts.minSimilarity);
   if (opts.namespace) body.namespace = opts.namespace;
   if (opts.tags) body.filters = { tags: opts.tags.split(',').map((t: string) => t.trim()) };

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -107,7 +107,10 @@ export async function cmdSearch(query: string, opts: ParsedArgs) {
 export async function cmdContext(query: string, opts: ParsedArgs) {
   const body: Record<string, any> = { query };
   if (opts.namespace) body.namespace = opts.namespace;
-  if (opts.limit != null && opts.limit !== true) body.limit = parseInt(opts.limit);
+  if (opts.limit != null && opts.limit !== true) {
+    const parsedLimit = parseInt(String(opts.limit));
+    if (!isNaN(parsedLimit) && parsedLimit > 0) body.limit = parsedLimit;
+  }
 
   const result = await request('POST', '/v1/context', body) as any;
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -368,6 +368,22 @@ describe('cmdRecall', () => {
     expect(consoleOutput.join('\n')).toContain('mem-123');
     restoreConsole();
   });
+
+  test('ignores non-numeric --limit value (NaN guard)', async () => {
+    mockFetchResponse = { memories: [] };
+    await cmdRecall('q', { _: [], limit: 'abc' } as any);
+    const body = getLastBody();
+    expect(body.limit).toBeUndefined();
+    restoreConsole();
+  });
+
+  test('ignores boolean --limit value (NaN guard)', async () => {
+    mockFetchResponse = { memories: [] };
+    await cmdRecall('q', { _: [], limit: true } as any);
+    const body = getLastBody();
+    expect(body.limit).toBeUndefined();
+    restoreConsole();
+  });
 });
 
 // ─── List ────────────────────────────────────────────────────────────────────
@@ -894,6 +910,21 @@ describe('cmdHistory', () => {
     expect(parsed.history).toBeDefined();
     restoreConsole();
   });
+
+  test('ignores non-numeric --limit (NaN guard)', async () => {
+    mockFetchResponse = {
+      history: [
+        { id: 'h1', created_at: '2025-01-01T00:00:00Z', changes: { content: true } },
+        { id: 'h2', created_at: '2025-01-02T00:00:00Z', changes: { importance: true } },
+      ]
+    };
+    await cmdHistory('abc', { _: [], limit: 'xyz' } as any);
+    const output = consoleOutput.join('\n');
+    // Should show all entries since invalid limit is ignored
+    expect(output).toContain('h1');
+    expect(output).toContain('h2');
+    restoreConsole();
+  });
 });
 
 // ─── Relations ───────────────────────────────────────────────────────────────
@@ -1010,6 +1041,14 @@ describe('cmdContext', () => {
     mockFetchResponse = { text: 'alt text field' };
     await cmdContext('q', { _: [] } as any);
     expect(consoleOutput.join('\n')).toContain('alt text field');
+    restoreConsole();
+  });
+
+  test('ignores non-numeric --limit value (NaN guard)', async () => {
+    mockFetchResponse = { context: 'ok' };
+    await cmdContext('q', { _: [], limit: 'xyz' } as any);
+    const body = getLastBody();
+    expect(body.limit).toBeUndefined();
     restoreConsole();
   });
 });
@@ -4127,5 +4166,32 @@ describe('move confirmation prompt (#206)', () => {
     expect(source).toContain('askConfirm');
     expect(source).toContain('skipConfirm');
     expect(source).toContain('process.stdin.isTTY');
+  });
+});
+
+// ─── #225: move --dry-run with explicit IDs ──────────────────────────────────
+
+describe('move --dry-run with explicit IDs (#225)', () => {
+  test('dry-run with explicit IDs does not call PATCH', async () => {
+    let patchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, opts: any) => {
+      if (opts?.method === 'PATCH') patchCalled = true;
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as any;
+
+    resetOutputState({ json: true });
+    captureConsole();
+    await cmdMove(['id-abc-123', 'id-def-456'], { _: ['move'], namespace: 'archive', dryRun: true } as any);
+    restoreConsole();
+    resetOutputState();
+
+    expect(patchCalled).toBe(false);
+    const parsed = JSON.parse(consoleOutput.join(''));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.would_move).toBe(2);
+
+    globalThis.fetch = origFetch;
+    setupMockFetch();
   });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs found during code audit:

### NaN guards for --limit parsing (Fixes #224, Fixes #226)

`recall`, `context`, and `history` commands used `parseInt(opts.limit)` without NaN validation. Passing non-numeric values like `--limit abc` would:
- **recall/context**: Send `NaN` (serialized as `null`) to the API
- **history**: Silently return empty results (`array.slice(-NaN)` → `[]`)

Now all commands validate parsed limit values and ignore invalid ones, matching the existing pattern in `search`.

### `move --dry-run` with explicit IDs (Fixes #225)

`memoclaw move <id> --namespace target --dry-run` silently ignored `--dry-run` and actually moved the memory. The dry-run check only existed for filter-based moves. Now it works consistently for both.

## Changes

- `src/commands/recall.ts`: NaN guard on `parseInt(opts.limit)`
- `src/commands/search.ts`: NaN guard on context command's `parseInt(opts.limit)`
- `src/commands/history.ts`: NaN guard on `parseInt(opts.limit)`
- `src/commands/memory.ts`: Add dry-run block for explicit ID moves
- `test/commands.test.ts`: 5 new tests covering all fixes

## Testing

All 651 tests pass (646 existing + 5 new).