### PR TITLE
fix: validate watch --interval to prevent tight polling loop

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -9,7 +9,11 @@ import { outputJson, outputFormat, out, outputWrite, table } from '../output.js'
 import { sortMemories } from './list.js';
 
 export async function cmdWatch(opts: ParsedArgs) {
-  const interval = parseInt(opts.interval || '3') * 1000;
+  const intervalSeconds = Number(opts.interval ?? '3');
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds < 1) {
+    throw new Error('Invalid --interval value. Must be a number >= 1 second.');
+  }
+  const interval = intervalSeconds * 1000;
   const params = new URLSearchParams();
   params.set('sort', 'created_at');
   params.set('order', 'desc');

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -2954,6 +2954,17 @@ describe('cmdWatch', () => {
     const mod = await import('../src/commands/watch.js');
     expect(typeof mod.cmdWatch).toBe('function');
   });
+
+  test('rejects non-numeric --interval', async () => {
+    const mod = await import('../src/commands/watch.js');
+    await expect(mod.cmdWatch({ _: ['watch'], interval: 'abc' } as any)).rejects.toThrow('Invalid --interval value');
+  });
+
+  test('rejects non-positive --interval', async () => {
+    const mod = await import('../src/commands/watch.js');
+    await expect(mod.cmdWatch({ _: ['watch'], interval: '-5' } as any)).rejects.toThrow('Invalid --interval value');
+    await expect(mod.cmdWatch({ _: ['watch'], interval: '0' } as any)).rejects.toThrow('Invalid --interval value');
+  });
 });
 
 // ─── #140: over-fetch when date filters active ──────────────────────────────


### PR DESCRIPTION
## Summary
- validate `--interval` in `cmdWatch` before entering the poll loop
- reject non-numeric and non-positive values with a clear error
- keep existing default interval behavior (`3` seconds) for valid input
- add tests for invalid `--interval` values (`abc`, `-5`, `0`)

## Testing
- bun test

Fixes #228
